### PR TITLE
Proper SystemExit exception handling for python 2.4

### DIFF
--- a/pgloader.py
+++ b/pgloader.py
@@ -775,7 +775,7 @@ if __name__ == "__main__":
     # SystemExit inherits from Exception in python < 2.5, so we have to
     # handle it separately.
     except SystemExit, e:
-	sys.exit(e.code)
+        sys.exit(e.code)
 
     except Exception, e:
         from pgloader.options import DEBUG


### PR DESCRIPTION
This patch is ensure that SystemExit exceptions are not treated as errors when python 2.4 is in use.
