### PR TITLE
Fixing "quote identifiers" option for MySQL conversions

### DIFF
--- a/src/sources/mysql.lisp
+++ b/src/sources/mysql.lisp
@@ -212,7 +212,8 @@
 	      ;; MySQL allows the same index name being used against several
 	      ;; tables, so we add the PostgreSQL table OID in the index name,
 	      ;; to differenciate. Set the table oids now.
-	      (set-table-oids all-indexes)
+	      (set-table-oids all-indexes
+                              :identifier-case identifier-case)
 
 	      ;; If asked to materialize views, now is the time to create
 	      ;; the target tables for them


### PR DESCRIPTION
This patch solves multiple bugs of migration MySQL to PostgreSQL with 'quote identifiers' mode on.

The only bug remaining (i didn't find non-dirty way to fix it) is wrong name of enum type. The enum itself is defined in PostgreSQL correctly quoted but it's referenced without quoting in table definition statement. These leads to error from PostgreSQL. But as i mentioned above i found no way to pass 'identifier-case' to mapping rules correctly. Maybe you can hint me with an idea - then i'll fix even this.

Anyway, looking forward for any feedback/comments.

Signed-off-by: Gleb Golubitsky sectoid@gnolltech.org
