### PR TITLE
Removed tinyint cast rule

### DIFF
--- a/test/parse/my.load
+++ b/test/parse/my.load
@@ -1,11 +1,11 @@
 load database from mysql://localhost/adv
               into postgresql://dim@localhost/adv
 
-with drop tables, truncate, create tables, create indexes,
+with include drop, truncate, create tables, create indexes,
      reset sequences,
      downcase identifiers
- set work_mem to '128MB', maintenance_work_mem to '512 MB'
+
+set work_mem to '128MB', maintenance_work_mem to '512 MB'
 
 cast type datetime to timestamptz drop default using zero-dates-to-null,
-     type date drop not null drop default using zero-dates-to-null,
-     type tinyint to boolean using tinyint-to-boolean;
+     type date drop not null drop default using zero-dates-to-null;


### PR DESCRIPTION
This rule has overridden the default rule for `tinyint(1)` and instead of placing `boolean`, it kept the typemod and placed `boolean(1)` into the resulting query.
