### PR TITLE
Updated shebang line

### DIFF
--- a/pgloader.lisp
+++ b/pgloader.lisp
@@ -1,4 +1,7 @@
-#! /usr/bin/sbcl --script
+#!/bin/sh
+#|
+exec sbcl --script "$0" $@
+|#
 
 ;;; load the necessary components then parse the command line
 ;;; and launch the work


### PR DESCRIPTION
Not everyone has SBCL installed in /usr/bin/sbcl and sometimes one wants to test other versions of SBCL or just not install the official Debian/Ubuntu packages. I have tested this on Ubuntu precise and it worked for me.

I got the info this would work from here:
https://bugs.launchpad.net/sbcl/+bug/1284148
