### PR TITLE
Take the default password from PGPASSWORD

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -328,7 +328,11 @@
 	     (or user
 		 (case type
 		   (:postgresql (getenv-default "PGUSER" (getenv-default "USER")))
-		   (:mysql      (getenv-default "USER"))))))
+		   (:mysql      (getenv-default "USER")))))
+          (password (or password
+              (case type
+                (:postgresql (getenv-default "PGPASSWORD"))
+                (:mysql (getenv-default "MYSQL_PWD"))))))
        (list :type type
 	     :user user
 	     :password password


### PR DESCRIPTION
pgloader accepts almost all traditional env variables for setting the connection, except for the password.

This patch implements that.
