### PR TITLE
Add support for MySQL mediumint auto increment

### DIFF
--- a/pgloader.1.md
+++ b/pgloader.1.md
@@ -1259,8 +1259,9 @@ Numbers:
   - type int with extra auto_increment to bigserial when (<= 10 precision)
   - type int to int       when  (< precision 10)
   - type int to bigint    when  (<= 10 precision)
-  - type smallint with extra auto_increment to serial
-  - type bigint   with extra auto_increment to bigserial
+  - type smallint  with extra auto_increment to serial
+  - type mediumint with extra auto_increment to serial
+  - type bigint    with extra auto_increment to bigserial
 
   - type tinyint to boolean when (= 1 precision) using tinyint-to-boolean
 

--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -54,8 +54,9 @@
     (:source (:type "int" :auto-increment nil :typemod (<= 10 precision))
      :target (:type "bigint"))
 
-    ;; bigint and smallint with auto_increment always are [big]serial
+    ;; bigint mediumint and smallint with auto_increment always are [big]serial
     (:source (:type "smallint" :auto-increment t) :target (:type "serial"))
+    (:source (:type "mediumint" :auto-increment t) :target (:type "serial"))
     (:source (:type "bigint" :auto-increment t) :target (:type "bigserial"))
 
     ;; actually tinyint(1) is most often used as a boolean
@@ -200,7 +201,8 @@
 	   ("l"  "char"      "char(1)"   nil "YES" nil)
 	   ("m"  "integer"   "integer(4)"    nil "YES" nil)
 	   ("o"  "tinyint"   "tinyint(1)" "0" nil nil)
-           ("p"  "smallint"  "smallint(5) unsigned" nil "no" "auto_increment"))))
+	   ("p"  "smallint"  "smallint(5) unsigned" nil "no" "auto_increment")
+	   ("q"  "mediumint" "integer"   nil "NO" "auto_increment"))))
 
     ;;
     ;; format-pgsql-column when given a mysql-column would call `cast' for


### PR DESCRIPTION
Hi,

I was migrating a MySQL database that uses MEDIUMINT types everywhere, including for auto incrementing primary keys.  pgloader doesn't seem to migrate the sequence itself.  This patch should add support for that.

Cheers,
Matt.
