### PR TITLE
Add support for MySQL tinyint auto increment

### DIFF
--- a/pgloader.1.md
+++ b/pgloader.1.md
@@ -1273,6 +1273,7 @@ Numbers:
   - type int with extra auto_increment to bigserial when (<= 10 precision)
   - type int to int       when  (< precision 10)
   - type int to bigint    when  (<= 10 precision)
+  - type tinyint   with extra auto_increment to serial
   - type smallint  with extra auto_increment to serial
   - type mediumint with extra auto_increment to serial
   - type bigint    with extra auto_increment to bigserial

--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -54,7 +54,8 @@
     (:source (:type "int" :auto-increment nil :typemod (<= 10 precision))
      :target (:type "bigint"))
 
-    ;; bigint mediumint and smallint with auto_increment always are [big]serial
+    ;; bigint mediumint smallint and tinyint with auto_increment always are [big]serial
+    (:source (:type "tinyint" :auto-increment t) :target (:type "serial"))
     (:source (:type "smallint" :auto-increment t) :target (:type "serial"))
     (:source (:type "mediumint" :auto-increment t) :target (:type "serial"))
     (:source (:type "bigint" :auto-increment t) :target (:type "bigserial"))
@@ -202,7 +203,8 @@
 	   ("m"  "integer"   "integer(4)"    nil "YES" nil)
 	   ("o"  "tinyint"   "tinyint(1)" "0" nil nil)
 	   ("p"  "smallint"  "smallint(5) unsigned" nil "no" "auto_increment")
-	   ("q"  "mediumint" "integer"   nil "NO" "auto_increment"))))
+	   ("q"  "mediumint" "integer"   nil "NO" "auto_increment")
+	   ("r"  "tinyint"   "integer"   nil "NO" "auto_increment"))))
 
     ;;
     ;; format-pgsql-column when given a mysql-column would call `cast' for


### PR DESCRIPTION
Hi Dimitri,

As it turns out, we have some TINYINT auto incrementing serials as well.

I've reloaded my database with this patch and the tinyint auto_increment fields in the source mysql db are being promoted to postgres serials on import.

Regards,
Matt.
