### PR TITLE
add missing conditional compilation for sbcl

### DIFF
--- a/src/parsers/command-mssql.lisp
+++ b/src/parsers/command-mssql.lisp
@@ -117,7 +117,7 @@
                                            (excluding))
   `(lambda ()
      ;; now is the time to load the CFFI lib we need (freetds)
-     (let ((sb-ext:*muffled-warnings* 'style-warning))
+     (let (#+sbcl(sb-ext:*muffled-warnings* 'style-warning))
        (cffi:load-foreign-library 'mssql::sybdb))
 
      (let* ((state-before  (pgloader.utils:make-pgstate))


### PR DESCRIPTION
Added missing #+sbcl for sb-ext:*muffled-warnings*.  prevented succesfully building the application with ccl