### PR TITLE
Missing quotes/escape on table names

### DIFF
--- a/src/pgsql/pgsql.lisp
+++ b/src/pgsql/pgsql.lisp
@@ -16,7 +16,7 @@
         ;; We need to keep a copy of the rows we send through the COPY
         ;; protocol to PostgreSQL to be able to process them again in case
         ;; of a data error being signaled, that's the BATCH here.
-        (let ((copier (cl-postgres:open-db-writer db table-name columns)))
+        (let ((copier (cl-postgres:open-db-writer db (s-sql:to-sql-name table-name) columns)))
           (unwind-protect
                (loop for i below batch-rows
                   for copy-string = (aref batch i)

--- a/src/sources/sqlite/sqlite-schema.lisp
+++ b/src/sources/sqlite/sqlite-schema.lisp
@@ -16,7 +16,7 @@
 
 (defun list-columns (table-name &optional (db *sqlite-db*))
   "Return the list of columns found in TABLE-NAME."
-  (let ((sql (format nil "PRAGMA table_info(~a)" table-name)))
+  (let ((sql (format nil "PRAGMA table_info('~a')" table-name)))
     (loop for (seq name type nullable default pk-id) in
 	 (sqlite:execute-to-list db sql)
        collect (make-coldef table-name

--- a/src/sources/sqlite/sqlite.lisp
+++ b/src/sources/sqlite/sqlite.lisp
@@ -47,7 +47,7 @@
 (defmethod map-rows ((sqlite copy-sqlite) &key process-row-fn)
   "Extract SQLite data and call PROCESS-ROW-FN function with a single
    argument (a list of column values) for each row"
-  (let ((sql      (format nil "SELECT * FROM ~a" (source sqlite)))
+  (let ((sql      (format nil "SELECT * FROM '~a'" (source sqlite)))
         (blobs-p
          (coerce (mapcar #'cast-to-bytea-p (fields sqlite)) 'vector)))
     (with-connection (*sqlite-db* (source-db sqlite))


### PR DESCRIPTION
Hello,

If you try to import a database with tables named "user" or "group", it won't work.
I add some quotes on sqlite files, I didn't check other sources :)