### PR TITLE
Allow dots in user names

### DIFF
--- a/src/parsers/command-db-uri.lisp
+++ b/src/parsers/command-db-uri.lisp
@@ -25,7 +25,14 @@
 (defrule doubled-at-sign (and "@@") (:constant "@"))
 (defrule doubled-colon   (and "::") (:constant ":"))
 (defrule password (+ (or (not "@") doubled-at-sign)) (:text t))
-(defrule username (and namestring (? (or doubled-at-sign doubled-colon)))
+(defrule username-string (and (or #\_ (alpha-char-p character))
+                              (* (or (alpha-char-p character)
+                                     (digit-char-p character)
+                                     #\.
+                                     punct)))
+  (:text t))
+
+(defrule username (and username-string (? (or doubled-at-sign doubled-colon)))
   (:text t))
 
 (defrule dsn-user-password (and username


### PR DESCRIPTION
Fix issue #168 by adding . in the punct defrule.