### PR TITLE
Fix 182: properly quote tables with . in their names

### DIFF
--- a/src/pgsql/schema.lisp
+++ b/src/pgsql/schema.lisp
@@ -26,7 +26,7 @@
           (cond ((quoted-p identifier)
                  :none)
 
-                ((cl-ppcre:scan "[^A-Za-z_]" identifier)
+                ((not (cl-ppcre:scan "^[A-Za-z_][A-Za-z0-9_$]*$" identifier))
                  :quote)
 
                 ((member lowercase-identifier *pgsql-reserved-keywords*

--- a/src/pgsql/schema.lisp
+++ b/src/pgsql/schema.lisp
@@ -26,7 +26,7 @@
           (cond ((quoted-p identifier)
                  :none)
 
-                ((cl-ppcre:scan "^[^A-Za-z_]" identifier)
+                ((cl-ppcre:scan "[^A-Za-z_]" identifier)
                  :quote)
 
                 ((member lowercase-identifier *pgsql-reserved-keywords*


### PR DESCRIPTION
Seems like it was a typo. Fixed #182 for me.