### PR TITLE
Fix explanation typo. Drop table if it exists

### DIFF
--- a/web/src/mysql.md
+++ b/web/src/mysql.md
@@ -103,7 +103,7 @@ Let's start the `pgloader` command with our `sakila.load` command file:
 
 The *WARNING* messages we see here are expected as the PostgreSQL database
 is empty when running the command, and pgloader is using the SQL commands
-`DROP TABLE IF NOT EXISTS` when the given command uses the `include drop`
+`DROP TABLE IF EXISTS` when the given command uses the `include drop`
 option.
 
 Note that the output of the command has been edited to facilitate its

--- a/web/src/sqlite.md
+++ b/web/src/sqlite.md
@@ -70,7 +70,7 @@ its HTTP URL location then *unziped* it before loading it.
 
 Also, the *WARNING* messages we see here are expected as the PostgreSQL
 database is empty when running the command, and pgloader is using the SQL
-commands `DROP TABLE IF NOT EXISTS` when the given command uses the `include
+commands `DROP TABLE IF EXISTS` when the given command uses the `include
 drop` option.
 
 Note that the output of the command has been edited to facilitate its


### PR DESCRIPTION
Hi Dimitri,

I think I found 2 typos in the fantastic PgLoader web documentation. Hope you are fine and to see you soon in one of your Postgresql talk ;-)