### PR TITLE
Match pgloader-standalone target to pgloader target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,13 +153,13 @@ $(PGLOADER): $(MANIFEST) $(BUILDAPP) $(LISP_SRC)
 pgloader: $(PGLOADER) ;
 
 pgloader-standalone:
-	$(BUILDAPP)    --require sb-posix                      \
-                       --require sb-bsd-sockets                \
-                       --require sb-rotate-byte                \
-                       --load-system pgloader                  \
+	$(BUILDAPP)    $(BUILDAPP_OPTS)                        \
+                       --sbcl $(CL)                            \
+                       --load-system $(APP_NAME)               \
+                       --load src/hooks.lisp                   \
                        --entry pgloader:main                   \
                        --dynamic-space-size $(DYNSIZE)         \
-                       --compress-core                         \
+                       $(COMPRESS_CORE_OPT)                    \
                        --output $(PGLOADER)
 
 test: $(PGLOADER)


### PR DESCRIPTION
It may have taken me a year, but [pgloader is finally in Homebrew](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/pgloader.rb)!

This PR brings a couple updates to the `pgloader-standalone` target to bring it in line with updates to the `pgloader` target. Things seem to work without this update, but I didn't test the SSL mess that `hooks.lisp` is supposed to address. (I know this dual-target Makefile is far from ideal, but I can't think of a better solution.)