### PR TITLE
Fix for #207

### DIFF
--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -100,7 +100,10 @@
          c.table_name,
          c.column_name,
          c.data_type,
-         c.column_default,
+         CASE
+             WHEN c.column_default LIKE '((%' AND c.column_default LIKE '%))' THEN SUBSTRING(c.column_default,3,len(c.column_default)-4)
+             WHEN c.column_default LIKE '(%' AND c.column_default LIKE '%)' THEN SUBSTRING(c.column_default,2,len(c.column_default)-2)
+         ELSE c.column_default END,
          c.is_nullable,
          COLUMNPROPERTY(object_id(c.table_name), c.column_name, 'IsIdentity'),
          c.CHARACTER_MAXIMUM_LENGTH,

--- a/src/utils/transforms.lisp
+++ b/src/utils/transforms.lisp
@@ -150,7 +150,7 @@
 (defun float-to-string (float)
   "Transform a Common Lisp float value into its string representation as
    accepted by PostgreSQL, that is 100.0 rather than 100.0d0."
-  (declare (type (or null float) float))
+  (declare (type (or null float string) float))
   (when float
     (typecase float
       (double-float (let ((*read-default-float-format* 'double-float))


### PR DESCRIPTION
Not sure why "0" is not interpreted as integer, string type used instead. 