### PR TITLE
Adds bootstrap for CentOS 7

### DIFF
--- a/bootstrap-centos7.sh
+++ b/bootstrap-centos7.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+sudo yum -y install yum-utils rpmdevtools @development-tools \
+                        sqlite-devel zlib-devel
+
+# Enable epel for sbcl
+sudo yum -y install epel-release
+sudo yum -y install sbcl 
+
+# Missing dependency
+sudo yum install freetds -y
+sudo ln -s /usr/lib64/libsybdb.so.5 /usr/lib64/libsybdb.so
+
+# prepare the rpmbuild setup
+rpmdev-setuptree


### PR DESCRIPTION
This corrects the bootstrap for CentOS 7.

Notes:
- During installation you still need to do the following:

  ```sh
sudo yum -y install freetds
sudo ln -s /usr/lib64/libsybdb.so.5 /usr/lib64/libsybdb.so
```

  I'm not sure which package depends on `libsybdb.so` to fix that.
- `--compress-core` is not available in the `sbcl` from epel. So I build the RPM with `make COMPRESS_CORE=no rpm`