### PR TITLE
MySQL bigint default convert's to NUMERIC(20)

### DIFF
--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -75,7 +75,7 @@
     (:source (:type "mediumint") :target (:type "integer"  :drop-typemod t))
     (:source (:type "integer")   :target (:type "integer"  :drop-typemod t))
     (:source (:type "float")     :target (:type "float"    :drop-typemod t))
-    (:source (:type "bigint")    :target (:type "bigint"   :drop-typemod t))
+    (:source (:type "bigint")    :target (:type "numeric(20)"   :drop-typemod t))
 
     (:source (:type "double")
 	     :target (:type "double precision" :drop-typemod t))


### PR DESCRIPTION
MySQL numeric data types are often 'optimized' to unsigned, so by default we need to convert MySQL's bigint to PG NUMERIC(20)