### PR TITLE
Default cast rules for MySQL's datatime types fixed

### DIFF
--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -136,8 +136,8 @@
 
     ;; date types without strange defaults
     (:source (:type "date")      :target (:type "date"))
-    (:source (:type "datetime")  :target (:type "timestamptz"))
-    (:source (:type "timestamp") :target (:type "timestamptz"))
+    (:source (:type "datetime")  :target (:type "timestamptz") :using pgloader.transforms::zero-dates-to-null)
+    (:source (:type "timestamp") :target (:type "timestamptz") :using pgloader.transforms::zero-dates-to-null)
     (:source (:type "year")      :target (:type "integer" :drop-typemod t))
 
     ;; Inline MySQL "interesting" datatype


### PR DESCRIPTION
See #252 for details.