### PR TITLE
MSSQL: handle nvarchar fields properly.

### DIFF
--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -8,7 +8,10 @@
   `((:source (:type "char")      :target (:type "text" :drop-typemod t))
     (:source (:type "nchar")     :target (:type "text" :drop-typemod t))
     (:source (:type "varchar")   :target (:type "text" :drop-typemod t))
-    (:source (:type "nvarchar")  :target (:type "text" :drop-typemod t))
+
+    (:source (:type "nvarchar")  :target (:type "text" :drop-typemod t) 
+             :using pgloader.transforms::sql-server-nvarchar-to-text)
+
     (:source (:type "xml")       :target (:type "text" :drop-typemod t))
 
     (:source (:type "bit") :target (:type "boolean")

--- a/src/utils/transforms.lisp
+++ b/src/utils/transforms.lisp
@@ -308,7 +308,8 @@
 (defun sql-server-nvarchar-to-text (str)
   "fix strings beginning N' in the data base: not especially that sometimes they have () as well!"
   (declare  (type (or null string) str))
-  (let ((result (string-trim "()" str)))
-    (when (and (> (length result) 1) (string= "N'" (subseq result 0 2)))
-      (setf result (string-trim "'" (subseq str 1))))
-    result))
+  (unless (null str)
+    (let ((result (string-trim "()" str)))
+      (when (and (> (length result) 1) (string= "N'" str :end2 2))
+        (setf result (string-trim "'" (subseq str 1))))
+      result)))

--- a/src/utils/transforms.lisp
+++ b/src/utils/transforms.lisp
@@ -271,6 +271,7 @@
                    (t
                     date-string-or-integer)))))))
 
+
 (defun sql-server-uniqueidentifier-to-uuid (id)
   (declare (type (or null (array (unsigned-byte 8) (16))) id))
   (when id
@@ -304,3 +305,10 @@
            ((string= "((1))" bit-string-or-integer) "t")
            (t nil)))))
 
+(defun sql-server-nvarchar-to-text (str)
+  "fix strings beginning N' in the data base: not especially that sometimes they have () as well!"
+  (declare  (type (or null string) str))
+  (let ((result (string-trim "()" str)))
+    (when (and (> (length result) 1) (string= "N'" (subseq result 0 2)))
+      (setf result (string-trim "'" (subseq str 1))))
+    result))


### PR DESCRIPTION
PGLoader was choking on the default values of nvarchar fields
So I added a transform to strip the N'...' delimiters around nvarchar
(unicode) fields and convert them to text automatically.

https://msdn.microsoft.com/en-us/library/ms179899.aspx
https://msdn.microsoft.com/en-us/library/ms186939.aspx
http://stackoverflow.com/questions/144283/what-is-the-difference-between-varchar-and-nvarchar
