### PR TITLE
Detect sbcl core compression and Makefile gardening.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,9 +60,9 @@ Now that the dependences are installed, just type make.
 
     make
 
-If using Mac OS X, and depending on how you did install `SBCL` and which
-version you have (the brew default did change recently), you might need to
-ask the Makefile to refrain from trying to compress your binary image:
+If your `SBCL` supports core compression, the make process will use it
+to generate a smaller binary.  To force disabling core compression, you
+may use:
 
     make COMPRESS_CORE=no
 
@@ -101,4 +101,3 @@ The `build` step install build dependencies in a debian jessie container,
 then `git clone` and build `pgloader` in `/opt/src/pgloader` and finally
 copy the resulting binary image in `/usr/local/bin/pgloader` so that it's
 easily available.
-

--- a/Makefile
+++ b/Makefile
@@ -35,27 +35,26 @@ BUILDAPP_CCL  = $(BUILDDIR)/bin/buildapp.ccl$(EXE)
 BUILDAPP_SBCL = $(BUILDDIR)/bin/buildapp.sbcl$(EXE)
 
 ifeq ($(CL),sbcl)
-BUILDAPP   = $(BUILDAPP_SBCL)
-CL_OPTS    = --no-sysinit --no-userinit
+BUILDAPP      = $(BUILDAPP_SBCL)
+BUILDAPP_OPTS = --require sb-posix                      \
+                --require sb-bsd-sockets                \
+                --require sb-rotate-byte
+CL_OPTS    = --noinform --no-sysinit --no-userinit
 else
 BUILDAPP   = $(BUILDAPP_CCL)
 CL_OPTS    = --no-init
 endif
 
-COMPRESS_CORE ?= yes
-
 ifeq ($(CL),sbcl)
+COMPRESS_CORE ?= $(shell $(CL) --noinform \
+                               --quit     \
+                               --eval '(when (member :sb-core-compression cl:*features*) (write-string "yes"))')
+
+endif
+
+# note: on Windows_NT, we never core-compress; see above.
 ifeq ($(COMPRESS_CORE),yes)
 COMPRESS_CORE_OPT = --compress-core
-else
-COMPRESS_CORE_OPT = 
-endif
-endif
-
-ifeq ($(CL),sbcl)
-BUILDAPP_OPTS =          --require sb-posix                      \
-                         --require sb-bsd-sockets                \
-                         --require sb-rotate-byte
 endif
 
 DEBUILD_ROOT = /tmp/pgloader

--- a/README.md
+++ b/README.md
@@ -103,13 +103,9 @@ binary image, though it's possible to build using
 
     $ make CL=ccl pgloader
 
-Note that the `Makefile` uses the `--compress-core` option when using SBCL,
-that should be enabled in your local copy of `SBCL`. If that's not the case,
-it's probably because you did compile and install `SBCL` yourself, so that
-you have a decently recent version to use. Then you need to compile it with
-the `--with-sb-core-compression` option.
-
-You can also remove the `--compress-core` option that way:
+If using `SBCL` and it supports core compression, the make process will
+use it to generate a smaller binary.  To force disabling core
+compression, you may use:
 
     $ make COMPRESS_CORE=no pgloader
 


### PR DESCRIPTION
Fedora 22 (quite new), Ubuntu 12.04 (old, but LTS), and perhaps other Linux distributions, compile SBCL without core-compression.

[As mentioned](https://github.com/dimitri/pgloader/issues/58#issuecomment-43108976), it would be helpful if the `Makefile` could detect core-compression if available, as opposed to asking users to manually use `make COMPRESS_CORE=no`.

This PR is an attempt at detection.  If it is acceptable, I'll modify the `README.md` as well, before this is merged.

(I also made a few small changes re-organizing the `Makefile` which I can remove, if they are not desired.)

##### Tail of `make pgloader`

Linux without core-compression:

```
;; loading system "pgloader"
;; loading file #P"/home/rmichael/source/pgloader/src/hooks.lisp"
[undoing binding stack and other enclosing state... done]
[saving current Lisp image into build/bin/pgloader.tmp:
writing 4944 bytes from the read-only space at 0x20000000
writing 4704 bytes from the static space at 0x20100000
writing 124157952 bytes from the dynamic space at 0x1000000000
done]
# that's ugly, but necessary when building on Windows :(
mv build/bin/pgloader.tmp build/bin/pgloader

$ build/bin/pgloader --version
pgloader version "3.2.2d0fb26"
compiled with SBCL 1.2.11-1.fc22
```

OS X with core-compression:
```
;; loading system "pgloader"
;; loading file #P"/Users/rmichael/Documents/Personal/Source/pgloader/src/hooks.lisp"
[undoing binding stack and other enclosing state... done]
[saving current Lisp image into build/bin/pgloader.tmp:
writing 4976 bytes from the read-only space at 0x20000000
compressed 32768 bytes into 1809 at level -1
writing 4704 bytes from the static space at 0x20100000
compressed 32768 bytes into 1554 at level -1
writing 121929728 bytes from the dynamic space at 0x1000000000
compressed 121929728 bytes into 22113988 at level -1
done]
# that's ugly, but necessary when building on Windows :(
mv build/bin/pgloader.tmp build/bin/pgloader

$ build/bin/pgloader --version
pgloader version "3.2.2d0fb26"
compiled with SBCL 1.3.0
```