### PR TITLE
fix type drop to cascade

### DIFF
--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -189,7 +189,7 @@
 	 (let* ((type-name
 		 (get-enum-type-name (mysql-column-table-name col)
 				     (mysql-column-name col))))
-           (format nil "DROP TYPE IF EXISTS ~a;" type-name)))
+           (format nil "DROP TYPE IF EXISTS ~a CASCADE;" type-name)))
 
        (get-create-enum (mysql-column-table-name col)
 			(mysql-column-name col)


### PR DESCRIPTION
if you have function or operator with  type which is removed, you will have error

error: cannot drop type because other objects depend on it