### PR TITLE
fix cast from float to real

### DIFF
--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -79,7 +79,7 @@
     (:source (:type "smallint")  :target (:type "smallint" :drop-typemod t))
     (:source (:type "mediumint") :target (:type "integer"  :drop-typemod t))
     (:source (:type "integer")   :target (:type "integer"  :drop-typemod t))
-    (:source (:type "float")     :target (:type "float"    :drop-typemod t))
+    (:source (:type "float")     :target (:type "real"    :drop-typemod t))
     (:source (:type "bigint")    :target (:type "bigint"   :drop-typemod t))
 
     (:source (:type "double")


### PR DESCRIPTION
PostgreSQL support SQL-standard notations float and float(p) BUT without precision it select double precision instead real.

http://www.postgresql.org/docs/current/static/datatype-numeric.html
last paragraph of 8.1.3
