### PR TITLE
Add the “set not null” cast option for MySQL

### DIFF
--- a/pgloader.1.md
+++ b/pgloader.1.md
@@ -1730,7 +1730,7 @@ The `database` command accepts the following clauses and options:
 	    The spelling *keep default* explicitly prevents that behaviour and
 	    can be used to overload the default casting rules.
 
-	  - *drop not null*, *keep not null*
+	  - *drop not null*, *keep not null*, *set not null*
 
         When the option *drop not null* is listed, pgloader drops any
         existing `NOT NULL` constraint associated with the given source
@@ -1739,6 +1739,10 @@ The `database` command accepts the following clauses and options:
 
 	    The spelling *keep not null* explicitly prevents that behaviour and
 	    can be used to overload the default casting rules.
+
+        When the option *set not null* is listed, pgloader sets a `NOT NULL`
+        constraint on the target column regardless whether it has been set
+        in the source MySQL column.
 
       - *drop typemod*, *keep typemod*
 

--- a/src/parsers/command-cast-rules.lisp
+++ b/src/parsers/command-cast-rules.lisp
@@ -75,21 +75,26 @@
 (defrule cast-drop-not-null (and kw-drop kw-not kw-null)
   (:constant (list :drop-not-null t)))
 
+(defrule cast-set-not-null (and kw-set kw-not kw-null)
+  (:constant (list :set-not-null t)))
+
 (defrule cast-def (+ (or cast-to-type
 			 cast-keep-default
 			 cast-drop-default
 			 cast-keep-typemod
 			 cast-drop-typemod
 			 cast-keep-not-null
-			 cast-drop-not-null))
+			 cast-drop-not-null
+                         cast-set-not-null))
   (:lambda (source)
     (destructuring-bind
-	  (&key type drop-default drop-typemod drop-not-null &allow-other-keys)
+	  (&key type drop-default drop-typemod drop-not-null set-not-null &allow-other-keys)
 	(apply #'append source)
       (list :type type
 	    :drop-default drop-default
 	    :drop-typemod drop-typemod
-	    :drop-not-null drop-not-null))))
+	    :drop-not-null drop-not-null
+            :set-not-null set-not-null))))
 
 (defun function-name-character-p (char)
   (or (member char #.(quote (coerce "/.-%" 'list)))

--- a/src/sources/common/casting-rules.lisp
+++ b/src/sources/common/casting-rules.lisp
@@ -91,6 +91,7 @@
 	(destructuring-bind (&key type
 				  drop-default
 				  drop-not-null
+                                  set-not-null
 				  (drop-typemod t)
 				  &allow-other-keys)
 	    target
@@ -108,7 +109,7 @@
                          :type-name type-name
                          :type-mod (when (and source-typemod (not drop-typemod))
                                      pg-typemod)
-                         :nullable (not (and source-not-null (not drop-not-null)))
+                         :nullable (and (not set-not-null) (or (not source-not-null) drop-not-null))
                          :default (when (and source-default (not drop-default))
                                     (format-default-value source-default using))
                          :transform using)))


### PR DESCRIPTION
Use case: Django dissuades setting `NULL` on text fields “on string-based fields […] because empty string values will always be stored as empty strings, not as `NULL`. If a string-based field has null=True, that means it has two possible values for »no data«: `NULL`, and the empty string. In most cases, it’s redundant to have two possible values for »no data«; the Django convention is to use the empty string, not `NULL`.”.

pgloader already supports custom transformations which can be used to replace `NULL` values in string-based columns with empty strings. Setting `NOT NULL` constraint on those columns could possibly be achieved by running a database query to extract their names and then generating relevant `ALTER TABLE` statements, but a cast option in pgloader is a more convenient way.

This pull requests lacks tests, as testing process in pgloader seems to be poorly documented and there is an encoding-related issue when running `make test` on my machine.