### PR TITLE
Shadow symbols NAMESTRING, NUMBER and INLINE in pgloader.parser package

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -665,6 +665,7 @@
 (defpackage #:pgloader.parser
   (:use #:cl #:esrap #:metabang.bind
         #:pgloader.params #:pgloader.utils #:pgloader.sql #:pgloader.connection)
+  (:shadow #:namestring #:number #:inline)
   (:import-from #:alexandria #:read-file-into-string)
   (:import-from #:pgloader.sources
                 #:md-connection


### PR DESCRIPTION
Defining rules on standard symbols like ``cl:namestring`` is a bad idea since other systems may do the same, inadvertently overwriting each other's rules.

Furthermore, future esrap versions will probably prevent defining rules whose names are symbols in locked packages, making this change mandatory.