### PR TITLE
Update pgloader.spec

### DIFF
--- a/pgloader.spec
+++ b/pgloader.spec
@@ -1,6 +1,6 @@
 Summary:            extract, transform and load data into PostgreSQL
 Name:               pgloader
-Version:            3.2.1.preview
+Version:            3.3.2
 Release:            22%{?dist}
 License:            The PostgreSQL Licence
 Group:              System Environment/Base


### PR DESCRIPTION
Updated version in spec - this is to enable to build a package using Makefile and the spec. The version in the Makefile is matched with the spec.

Without this change:
`make rpm`
throws below error:

```
[root@ip-xx-yyy-zz-246 pgloader]# make rpm
# intended for use on a CentOS or other RPM based system
mkdir -p /tmp/pgloader && rm -rf /tmp/pgloader
rsync -Ca --exclude=build/* ./ /tmp/pgloader/
cd /tmp && tar czf /root/rpmbuild/SOURCES/pgloader-3.3.2.tar.gz pgloader
cd /tmp/pgloader && rpmbuild -ba pgloader.spec
error: File /root/rpmbuild/SOURCES/pgloader-**3.2.1.preview.**tar.gz: No such file or directory
make: *** [rpm] Error 1
```