### PR TITLE
MSSQL: Add support for typemods of various text types

### DIFF
--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -106,6 +106,11 @@
                           type
                           (mssql-column-numeric-precision col)
                           (or (mssql-column-numeric-scale col) 0)))))
+          ((member type '("char" "nchar" "varchar" "nvarchar" "binary") :test #'string=)
+           ;; the user might have a CAST rule with keep typemod, so we need
+           ;; to deal with character-maximum-length for now
+           (format nil "~a(~a)"
+                   type (mssql-column-character-maximum-length col)))
 
           (t type))))
 


### PR DESCRIPTION
If a custom CAST rule is defined (e.g CAST type varchar to varchar) the
original typemod get's lost. This commit is based on Dimitris patch from
571 and adds typmod support for "char", "nchar", "varchar", "nvarchar"
and "binary".