### PR TITLE
MSSQL: fix typmod conversion for "max" typemods

### DIFF
--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -106,11 +106,16 @@
                           type
                           (mssql-column-numeric-precision col)
                           (or (mssql-column-numeric-scale col) 0)))))
-          ((member type '("char" "nchar" "varchar" "nvarchar" "binary") :test #'string=)
+
+          ((member type '("char" "nchar" "varchar" "nvarchar" "binary")
+                   :test #'string=)
            ;; the user might have a CAST rule with keep typemod, so we need
            ;; to deal with character-maximum-length for now
-           (format nil "~a(~a)"
-                   type (mssql-column-character-maximum-length col)))
+
+           (if (= -1 (mssql-column-character-maximum-length col))
+               type
+               (format nil "~a(~a)"
+                       type (mssql-column-character-maximum-length col))))
 
           (t type))))
 


### PR DESCRIPTION
The previous commit makes it possible to convert typemods for various
text types. In MSSQL it's possible to create a column like varchar(max).
Internally this is reported as varchar(-1) which results in a CREATE
TABLE statement that contains e.g. varchar(-1).

This patch drops the typemod if it's -1 (max).

It's based on Dimitris patch slightly modified by myself.