### PR TITLE
MSSQL: Fix Default value translation for getdate() (#576)

### DIFF
--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -93,7 +93,7 @@
              CASE
                  WHEN SUBSTRING(c.column_default,3,len(c.column_default)-4) = 'newid()' THEN 'generate_uuid_v4()'
                  WHEN SUBSTRING(c.column_default,3,len(c.column_default)-4) LIKE 'convert(%varchar%,getdate(),%)' THEN 'today'
-                 WHEN SUBSTRING(c.column_default,3,len(c.column_default)-4) = 'getdate()' THEN 'now'
+                 WHEN SUBSTRING(c.column_default,3,len(c.column_default)-4) = 'getdate()' THEN 'CURRENT_TIMESTAMP'
                  WHEN SUBSTRING(c.column_default,3,len(c.column_default)-4) LIKE '''%''' THEN SUBSTRING(c.column_default,4,len(c.column_default)-6)
                  ELSE SUBSTRING(c.column_default,3,len(c.column_default)-4)
              END
@@ -101,7 +101,7 @@
              CASE
                  WHEN SUBSTRING(c.column_default,2,len(c.column_default)-2) = 'newid()' THEN 'generate_uuid_v4()'
                  WHEN SUBSTRING(c.column_default,2,len(c.column_default)-2) LIKE 'convert(%varchar%,getdate(),%)' THEN 'today'
-                 WHEN SUBSTRING(c.column_default,2,len(c.column_default)-2) = 'getdate()' THEN 'now'
+                 WHEN SUBSTRING(c.column_default,2,len(c.column_default)-2) = 'getdate()' THEN 'CURRENT_TIMESTAMP'
                  WHEN SUBSTRING(c.column_default,2,len(c.column_default)-2) LIKE '''%''' THEN SUBSTRING(c.column_default,3,len(c.column_default)-4)
                  ELSE SUBSTRING(c.column_default,2,len(c.column_default)-2)
              END


### PR DESCRIPTION
Currently the default value getdate() is replaced by 'now' which creates
statements like:
  CREATE TABLE ... created timestamp 'now' ...
which leads to table definitions like:
  default '2017-06-12 17:54:04.890129'::timestamp without time zone

This is because 'now' is evaluated when creating the table.

This commit fixes the issue by using CURRENT_TIMESTAMP as default
instead of 'now'.