### PR TITLE
Fix the brew install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ it builds aginst current set of dependencies versions.
 ### Building from sources on MacOSX
 
 When using [brew](https://brew.sh), it should be a simple `brew install
---head pgloader`.
+--HEAD pgloader`.
 
 When using [macports](https://www.macports.org), then we have a situation to
 deal with with shared objects pgloader depends on, as reported in issue #161


### PR DESCRIPTION
If you run 

```
brew install --head pgloader
```

the brew will error out with the message

```
Error: Specify `--HEAD` in uppercase to build from trunk.
```