### PR TITLE
Ignore nulls in varbinary-to-string transform

### DIFF
--- a/src/utils/transforms.lisp
+++ b/src/utils/transforms.lisp
@@ -337,5 +337,6 @@
          (or qmynd::*mysql-encoding*
              babel::*default-character-encoding*)))
     (etypecase string
+      (null nil)
       (string string)
       (vector (babel:octets-to-string string)))))


### PR DESCRIPTION
I've tested this on one of my import jobs and can confirm that the rows containing a `NULL` `binary(n)` value are preserved.