### PR TITLE
Hack to allow unique indexes to convert to db with btree_gin installed

### DIFF
--- a/src/pgsql/sql/list-typenames-without-btree-support.sql
+++ b/src/pgsql/sql/list-typenames-without-btree-support.sql
@@ -12,4 +12,5 @@ select typname,
                 join pg_type t on c.opcintype = t.oid
           where amname = 'btree' and t.oid = pg_type.oid
        )
+       and typname not in ('varchar', 'cidr')
 group by typname;


### PR DESCRIPTION
Almost certainly not a proper fix, but this is what we needed to do recently when migrating a MySQL database to a PostgreSQL instance with the btree_gin extension installed.

To reproduce...

MySQL:

`CREATE TABLE foo (bar varchar(20), constraint bar_uniq unique (bar));`

PostgreSQL:

`create extension btree_gin;`

Converting with pgloader produces the following error:

```
2017-12-01T00:31:49.841000Z ERROR PostgreSQL Database error 0A000: access method "gin" does not support unique indexes
QUERY: CREATE UNIQUE INDEX idx_1108501_bar_uniq ON test_db.foo USING gin(bar);
```

Thanks for all the work on pgloader, hopefully the proper fix is obvious for someone more familiar with the system catalogs.