### PR TITLE
doc: fix a few link format

### DIFF
--- a/docs/tutorial/csv.rst
+++ b/docs/tutorial/csv.rst
@@ -7,9 +7,8 @@ specifications. pgloader allows you to describe those specs in its command.
 The Command
 ^^^^^^^^^^^
 
-To load data with [pgloader](http://pgloader.io/) you need to define in a
-*command* the operations in some details. Here's our example for loading CSV
-data::
+To load data with pgloader you need to define in a *command* the operations in
+some details. Here's our example for loading CSV data::
 
      LOAD CSV
           FROM 'path/to/file.csv' (x, y, a, b, c, d)

--- a/docs/tutorial/dBase.rst
+++ b/docs/tutorial/dBase.rst
@@ -8,9 +8,9 @@ support in modern tools, pgloader is right there on the list too!
 The Command
 ^^^^^^^^^^^
 
-To load data with [pgloader](http://pgloader.io/) you need to define in a
-*command* the operations in some details. Here's our example for loading a
-dBase file, using a file provided by the french administration.
+To load data with pgloader you need to define in a *command* the operations in
+some details. Here's our example for loading a dBase file, using a file
+provided by the french administration.
 
 You can find more files from them at the `Insee
 <http://www.insee.fr/fr/methodes/nomenclatures/cog/telechargement.asp>`_

--- a/docs/tutorial/fixed.rst
+++ b/docs/tutorial/fixed.rst
@@ -8,9 +8,9 @@ blank-padded when the data is shorter than the full reserved range.
 The Command
 ^^^^^^^^^^^
 
-To load data with [pgloader](http://pgloader.io/) you need to define in a
-*command* the operations in some details. Here's our example for loading
-Fixed Width Data, using a file provided by the US census.
+To load data with pgloader you need to define in a *command* the operations in
+some details. Here's our example for loading Fixed Width Data, using a file
+provided by the US census.
 
 You can find more files from them at the
 [Census 2000 Gazetteer Files](http://www.census.gov/geo/maps-data/data/gazetteer2000.html).

--- a/docs/tutorial/sqlite.rst
+++ b/docs/tutorial/sqlite.rst
@@ -3,8 +3,10 @@ Loading SQLite files with pgloader
 
 The SQLite database is a respected solution to manage your data with. Its
 embeded nature makes it a source of migrations when a projects now needs to
-handle more concurrency, which [PostgreSQL](http://www.postgresql.org/) is
-very good at. pgloader can help you there.
+handle more concurrency, which PostgreSQL_ is very good at. pgloader can help
+you there.
+
+.. _PostgreSQL: http://www.postgresql.org/
 
 In a Single Command Line
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,8 +64,8 @@ can use the pgloader command.
 The Command
 ^^^^^^^^^^^
 
-To load data with [pgloader](http://pgloader.io/) you need to define in a
-*command* the operations in some details. Here's our command::
+To load data with pgloader you need to define in a *command* the operations in
+some details. Here's our command::
 
     load database
          from 'sqlite/Chinook_Sqlite_AutoIncrementPKs.sqlite'


### PR DESCRIPTION
They are still in Markdown format, remove or move to rst.