### PR TITLE
Fix minor error in docs about logfile location

### DIFF
--- a/docs/pgloader.rst
+++ b/docs/pgloader.rst
@@ -104,7 +104,7 @@ Those options are meant to tweak `pgloader` behavior when loading data.
 
   * `-L`, `--logfile`
     
-    Set the pgloader log file (default to "/tmp/pgloader.log").
+    Set the pgloader log file (default to "/tmp/pgloader/pgloader.log").
 
   * `--log-min-messages`
     


### PR DESCRIPTION
The default logfile location seems to be `/tmp/pgloader/pgloader.log`, not `/tmp/pgloader.log` as currently documented. This is observable in practice and also in [the source code](https://github.com/dimitri/pgloader/blob/5b227200a9525050ce60e44e2bc899a3c2b1f018/src/main.lisp#L110).