### PR TITLE
Correct binary datatype changes

### DIFF
--- a/docs/ref/mysql.rst
+++ b/docs/ref/mysql.rst
@@ -590,7 +590,7 @@ Texts::
   type mediumtext to text using remove-null-characters
   type longtext   to text using remove-null-characters
 
-Binary:
+Binary::
 
   type binary     to bytea
   type varbinary  to bytea


### PR DESCRIPTION
When reading http://pgloader.readthedocs.io/en/latest/ref/mysql.html I came across the section of binary. On the documentation the indentation is off and is kinda hard to read :)