### PR TITLE
Added how to install w/brew w/o postgresql server dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ it builds aginst current set of dependencies versions.
 ### Building from sources on macOS
 
 When using [brew](https://brew.sh), it should be a simple `brew install
---HEAD pgloader`.
+--HEAD pgloader`. To install *without postresql* `brew install --HEAD pgloader --ignore-dependencies coq`.
 
 When using [macports](https://www.macports.org), then we have a situation to
 deal with with shared objects pgloader depends on, as reported in issue #161


### PR DESCRIPTION
Handy standalone install using Homebrew without postgresql server dependency. Handy if using another approach to where your PostgreSQL server lives (like https://github.com/PostgresApp/PostgresApp) and you want to keep things tidy! This was an issue that led to this solution: https://github.com/dimitri/pgloader/issues/588