### PR TITLE
Improved Dockerfiles/docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .git
 .vagrant
 build
+Dockerfile
+Dockerfile.ccl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,30 @@
 FROM debian:stretch
-MAINTAINER Dimitri Fontaine <dim@tapoueh.org>
 
-RUN apt-get update                                   && \
-    apt-get install -y --no-install-recommends          \
-                    wget curl make git bzip2 time       \
-                    ca-certificates                     \
-                    libzip-dev libssl1.1 openssl        \
-                    patch unzip libsqlite3-dev gawk     \
-                    freetds-dev sbcl                 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      bzip2 \
+      ca-certificates \
+      curl \
+      freetds-dev \
+      gawk \
+      git \
+      libsqlite3-dev \
+      libssl1.1 \
+      libzip-dev \
+      make \
+      openssl \
+      patch \
+      sbcl \
+      time \
+      unzip \
+      wget \
+    && rm -rf /var/lib/apt/lists/*
 
-ADD ./ /opt/src/pgloader
-WORKDIR /opt/src/pgloader
+COPY ./ /opt/src/pgloader
 
-# build/ is in the .dockerignore file, but we actually need it now
-RUN mkdir -p build/bin
-RUN make
+RUN mkdir -p /opt/src/pgloader/build/bin \
+    && cd /opt/src/pgloader \
+    && make \
+    && mv /opt/src/pgloader/build/bin/pgloader /usr/local/bin
 
-RUN cp /opt/src/pgloader/build/bin/pgloader /usr/local/bin
+LABEL maintainer="Dimitri Fontaine <dim@tapoueh.org>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stable-slim as builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -24,7 +24,22 @@ COPY ./ /opt/src/pgloader
 
 RUN mkdir -p /opt/src/pgloader/build/bin \
     && cd /opt/src/pgloader \
-    && make \
-    && mv /opt/src/pgloader/build/bin/pgloader /usr/local/bin
+    && make
+
+FROM debian:stable-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      curl \
+      freetds-dev \
+      gawk \
+      libsqlite3-dev \
+      libzip-dev \
+      make \
+      sbcl \
+      unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/src/pgloader/build/bin/pgloader /usr/local/bin
 
 LABEL maintainer="Dimitri Fontaine <dim@tapoueh.org>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,45 @@
 FROM debian:stable-slim as builder
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      bzip2 \
-      ca-certificates \
-      curl \
-      freetds-dev \
-      gawk \
-      git \
-      libsqlite3-dev \
-      libssl1.1 \
-      libzip-dev \
-      make \
-      openssl \
-      patch \
-      sbcl \
-      time \
-      unzip \
-      wget \
-    && rm -rf /var/lib/apt/lists/*
+  RUN apt-get update \
+      && apt-get install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        curl \
+        freetds-dev \
+        gawk \
+        git \
+        libsqlite3-dev \
+        libssl1.1 \
+        libzip-dev \
+        make \
+        openssl \
+        patch \
+        sbcl \
+        time \
+        unzip \
+        wget \
+      && rm -rf /var/lib/apt/lists/*
 
-COPY ./ /opt/src/pgloader
+  COPY ./ /opt/src/pgloader
 
-RUN mkdir -p /opt/src/pgloader/build/bin \
-    && cd /opt/src/pgloader \
-    && make
+  RUN mkdir -p /opt/src/pgloader/build/bin \
+      && cd /opt/src/pgloader \
+      && make
 
 FROM debian:stable-slim
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-      curl \
-      freetds-dev \
-      gawk \
-      libsqlite3-dev \
-      libzip-dev \
-      make \
-      sbcl \
-      unzip \
-    && rm -rf /var/lib/apt/lists/*
+  RUN apt-get update \
+      && apt-get install -y --no-install-recommends \
+        curl \
+        freetds-dev \
+        gawk \
+        libsqlite3-dev \
+        libzip-dev \
+        make \
+        sbcl \
+        unzip \
+      && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /opt/src/pgloader/build/bin/pgloader /usr/local/bin
+  COPY --from=builder /opt/src/pgloader/build/bin/pgloader /usr/local/bin
 
-LABEL maintainer="Dimitri Fontaine <dim@tapoueh.org>"
+  LABEL maintainer="Dimitri Fontaine <dim@tapoueh.org>"

--- a/Dockerfile.ccl
+++ b/Dockerfile.ccl
@@ -1,25 +1,49 @@
-FROM debian:stretch
-MAINTAINER Dimitri Fontaine <dim@tapoueh.org>
+FROM debian:stable-slim as builder
 
-RUN apt-get update                                   && \
-    apt-get install -y --no-install-recommends          \
-                    wget curl make git bzip2 time       \
-                    ca-certificates                     \
-                    libzip-dev libssl1.1 openssl        \
-                    patch unzip libsqlite3-dev gawk     \
-                    freetds-dev sbcl                 && \
-    rm -rf /var/lib/apt/lists/*
+  RUN apt-get update \
+      && apt-get install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        curl \
+        freetds-dev \
+        gawk \
+        git \
+        libsqlite3-dev \
+        libssl1.1 \
+        libzip-dev \
+        make \
+        openssl \
+        patch \
+        sbcl \
+        time \
+        unzip \
+        wget \
+      && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/local/src
-RUN curl --location -O https://github.com/Clozure/ccl/releases/download/v1.11.5/ccl-1.11.5-linuxx86.tar.gz
-RUN tar xf ccl-1.11.5-linuxx86.tar.gz
-RUN cp /usr/local/src/ccl/scripts/ccl64 /usr/local/bin/ccl
+  RUN curl -SL https://github.com/Clozure/ccl/releases/download/v1.11.5/ccl-1.11.5-linuxx86.tar.gz \
+      | tar xz -C /usr/local/src/ \
+      && mv /usr/local/src/ccl/scripts/ccl64 /usr/local/bin/ccl
 
-ADD ./ /opt/src/pgloader
-WORKDIR /opt/src/pgloader
+  COPY ./ /opt/src/pgloader
 
-# build/ is in the .dockerignore file, but we actually need it now
-RUN mkdir -p build/bin
-RUN make CL=ccl DYNSIZE=256
+  RUN mkdir -p /opt/src/pgloader/build/bin \
+      && cd /opt/src/pgloader \
+      && make CL=ccl DYNSIZE=256
 
-RUN cp /opt/src/pgloader/build/bin/pgloader /usr/local/bin
+FROM debian:stable-slim
+
+  RUN apt-get update \
+      && apt-get install -y --no-install-recommends \
+        curl \
+        freetds-dev \
+        gawk \
+        libsqlite3-dev \
+        libzip-dev \
+        make \
+        sbcl \
+        unzip \
+      && rm -rf /var/lib/apt/lists/*
+
+  COPY --from=builder /opt/src/pgloader/build/bin/pgloader /usr/local/bin
+
+  LABEL maintainer="Dimitri Fontaine <dim@tapoueh.org>"


### PR DESCRIPTION
Reduced size of the docker images by using smaller base image and multistage builds:

```
dimitri/pgloader   latest       452MB
pgloader           latest       171MB

dimitri/pgloader   ccl.latest   730MB
pgloader           ccl.latest   248MB

```

Also reduced layer count of the images.

We could save even more space by installing as few packages as possible. You don't need `make` etc. in the final container. Installing less packages inside the builder container could also improve build time.

I think the package requirements in README are outdated. Some packages are missing and some others are only required during compilation.