### PR TITLE
Fix pgloader bug #844 by adding support for mssql real types

### DIFF
--- a/src/monkey/mssql.lisp
+++ b/src/monkey/mssql.lisp
@@ -93,6 +93,7 @@
              (:syb-int2 (unsigned-to-signed (mem-ref data :unsigned-int) 2))
              (:syb-int4 (unsigned-to-signed (mem-ref data :unsigned-int) 4))
              (:syb-int8 (mem-ref data :int8))
+             (:syb-real (mem-ref data :float))
              (:syb-flt8 (mem-ref data :double))
              ((:syb-datetime :syb-datetime4 :syb-msdate)
               (with-foreign-pointer (%buf +numeric-buf-sz+)


### PR DESCRIPTION
syb-real is a 4 byte float, which seems to correspond exactly to the lisp type float