### PR TITLE
add cl-ironclad and cl-babel dependencies to docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ FROM debian:stable-slim as builder
         time \
         unzip \
         wget \
+        cl-ironclad \
+        cl-babel \
       && rm -rf /var/lib/apt/lists/*
 
   COPY ./ /opt/src/pgloader

--- a/Dockerfile.ccl
+++ b/Dockerfile.ccl
@@ -18,6 +18,8 @@ FROM debian:stable-slim as builder
         time \
         unzip \
         wget \
+        cl-ironclad \
+        cl-babel \
       && rm -rf /var/lib/apt/lists/*
 
   RUN curl -SL https://github.com/Clozure/ccl/releases/download/v1.11.5/ccl-1.11.5-linuxx86.tar.gz \


### PR DESCRIPTION
I had some issues building using the supplied Dockerfiles (I tried the CCL version only, in this case) that were resolved by adding two packages from apt: cl-ironclad and cl-babel. Contributing back the changes here.