### PR TITLE
Allow "preserve index names" for MSSQL

### DIFF
--- a/src/parsers/command-mssql.lisp
+++ b/src/parsers/command-mssql.lisp
@@ -31,6 +31,7 @@
                           option-create-tables
                           option-create-schemas
                           option-create-indexes
+			  option-index-names
                           option-reset-sequences
 			  option-foreign-keys
                           option-encoding


### PR DESCRIPTION
With this change, preserve index names is also supported for MSSQL-connections.