### PR TITLE
Fix ccl docker images not having libssl

### DIFF
--- a/Dockerfile.ccl
+++ b/Dockerfile.ccl
@@ -39,6 +39,7 @@ FROM debian:stable-slim
         freetds-dev \
         gawk \
         libsqlite3-dev \
+        libssl1.1 \
         libzip-dev \
         make \
         sbcl \


### PR DESCRIPTION
pgloader:ccl.latest throws an error: Shared library not open: "libssl.so.1.1". This commit adds libssl1.1 to the docker image which fixes the issue.