### PR TITLE
fix(mysql): use new st_astext function

### DIFF
--- a/src/sources/mysql/mysql-schema.lisp
+++ b/src/sources/mysql/mysql-schema.lisp
@@ -197,12 +197,12 @@
   "Return per-TYPE SQL expression to use given a column NAME.
 
    Mostly we just use the name, but in case of POINT we need to use
-   astext(name)."
+   st_astext(name)."
   (declare (ignore mysql))
   (case (intern (string-upcase type) "KEYWORD")
-    (:geometry   (format nil "astext(`~a`) as `~a`" name name))
-    (:point      (format nil "astext(`~a`) as `~a`" name name))
-    (:linestring (format nil "astext(`~a`) as `~a`" name name))
+    (:geometry   (format nil "st_astext(`~a`) as `~a`" name name))
+    (:point      (format nil "st_astext(`~a`) as `~a`" name name))
+    (:linestring (format nil "st_astext(`~a`) as `~a`" name name))
     (t           (format nil "`~a`" name))))
 
 (defmethod get-column-list ((mysql copy-mysql))


### PR DESCRIPTION
Fix: https://github.com/dimitri/pgloader/issues/1029

This PR use the st_astext function instead of astext that has been removed since mysql 8+


For info: ST_ASTEXT is available since mysql 5.6+ ([link](https://dev.mysql.com/doc/refman/5.6/en/gis-format-conversion-functions.html#function_st-astext))

