### PR TITLE
Update Quicklisp dist to 2020-02-18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ QLDIR      = $(BUILDDIR)/quicklisp
 MANIFEST   = $(BUILDDIR)/manifest.ql
 LATEST     = $(BUILDDIR)/pgloader-latest.tgz
 
-BUNDLEDIST = 2019-01-07
+BUNDLEDIST = 2020-02-18
 BUNDLENAME = pgloader-bundle-$(VERSION)
 BUNDLEDIR  = $(BUILDDIR)/bundle/$(BUNDLENAME)
 BUNDLE     = $(BUILDDIR)/$(BUNDLENAME).tgz


### PR DESCRIPTION
#1092 requires us to switch to a new Quicklisp distribution in order to bump CFFI to version 0.21.0. This commit switches to the newest available QL dist (2020-02-18) to achieve this.