### PR TITLE
Change Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ sudo: required
 
 env:
   matrix:
-    - LISP=ccl
     - LISP=ccl  PGVERSION=9.6
-    - LISP=sbcl
+    - LISP=ccl  PGVERSION=10
+    - LISP=ccl  PGVERSION=11
+    - LISP=ccl  PGVERSION=12
     - LISP=sbcl PGVERSION=9.6
+    - LISP=sbcl PGVERSION=10
+    - LISP=sbcl PGVERSION=11
+    - LISP=sbcl PGVERSION=12
 
 install:
   - ./.travis.sh lisp_install


### PR DESCRIPTION
We remove the Travis jobs without the `PGLOADER` environment variable set (to try and fix #1109) and add Postgres versions 10, 11, and 12 to build and test pgloader against them (to try and fix #1108).

Please merge only if [the related Travis job](https://travis-ci.org/github/dimitri/pgloader/builds/666266112) succeeds.