### PR TITLE
Simplify and fix errors/warnings/notes on Travis configuration

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -43,20 +43,9 @@ pgdg_repositories() {
 }
 
 postgresql_install() {
-	if [ -z "${PGVERSION:-}" ]; then
-		PGVERSION="$( psql -d postgres -XAtc "select regexp_replace(current_setting('server_version'), '[.][0-9]+$', '')" )"
-	else
-		sudo service postgresql stop
-		xargs sudo apt-get -y --purge remove <<-packages
-			libpq-dev
-			libpq5
-			postgresql
-			postgresql-client-common
-			postgresql-common
-		packages
-		sudo rm -rf /var/lib/postgresql
-	fi
-
+        if [ -z "${PGVERSION:-}" ]; then
+                PGVERSION="$( psql -d postgres -XAtc "select regexp_replace(current_setting('server_version'), '[.][0-9]+$', '')" )"
+        fi
 	xargs sudo apt-get -y install <<-packages
 		postgresql-${PGVERSION}
 		postgresql-${PGVERSION}-ip4r

--- a/.travis.sh
+++ b/.travis.sh
@@ -43,9 +43,10 @@ pgdg_repositories() {
 }
 
 postgresql_install() {
-        if [ -z "${PGVERSION:-}" ]; then
-                PGVERSION="$( psql -d postgres -XAtc "select regexp_replace(current_setting('server_version'), '[.][0-9]+$', '')" )"
-        fi
+	if [ -z "${PGVERSION:-}" ]; then
+		echo 'PGVERSION environment variable not set.';
+		exit 1
+	fi
 	xargs sudo apt-get -y install <<-packages
 		postgresql-${PGVERSION}
 		postgresql-${PGVERSION}-ip4r

--- a/.travis.sh
+++ b/.travis.sh
@@ -47,6 +47,7 @@ postgresql_install() {
 		echo 'PGVERSION environment variable not set.';
 		exit 1
 	fi
+
 	xargs sudo apt-get -y install <<-packages
 		postgresql-${PGVERSION}
 		postgresql-${PGVERSION}-ip4r

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-language: common-lisp
-sudo: required
+language: shell
+os: linux
+dist: xenial
 
 env:
-  matrix:
+  jobs:
     - LISP=ccl
     - LISP=ccl  PGVERSION=9.6
     - LISP=sbcl


### PR DESCRIPTION
Fixes #1111.

We remove unnecessary .travis.sh code for removing old Postgres versions.