### PR TITLE
handling mssql datetimeoffset

### DIFF
--- a/src/monkey/mssql.lisp
+++ b/src/monkey/mssql.lisp
@@ -99,7 +99,8 @@
                :syb-datetime4
                :syb-msdate
                :syb-mstime
-               :syb-msdatetime2)
+               :syb-msdatetime2
+               :syb-msdatetimeoffset)
               (with-foreign-pointer (%buf +numeric-buf-sz+)
                 (let ((count
                        (%dbconvert %dbproc

--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -64,7 +64,8 @@
 
     (:source (:type "smalldatetime") :target (:type "timestamptz"))
     (:source (:type "datetime") :target (:type "timestamptz"))
-    (:source (:type "datetime2") :target (:type "timestamptz")))
+    (:source (:type "datetime2") :target (:type "timestamptz"))
+    (:source (:type "datetimeoffset") :target (:type "timestamptz")))
   "Data Type Casting to migrate from MSSQL to PostgreSQL")
 
 ;;;

--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -168,11 +168,12 @@
 
    Mostly we just use the name, and make try to avoid parsing dates."
   (case (intern (string-upcase type) "KEYWORD")
-    (:time           (format nil "convert(varchar, [~a], 114)" name))
-    (:datetime       (format nil "convert(varchar, [~a], 126)" name))
-    (:datetime2      (format nil "convert(varchar, [~a], 126)" name))
-    (:smalldatetime  (format nil "convert(varchar, [~a], 126)" name))
-    (:date           (format nil "convert(varchar, [~a], 126)" name))
+    (:time           (format nil "convert(varchar(30), [~a], 114)" name))
+    (:datetime       (format nil "convert(varchar(30), [~a], 126)" name))
+    (:datetime2      (format nil "convert(varchar(30), [~a], 126)" name))
+    (:datetimeoffset (format nil "convert(varchar(35), [~a], 127)" name))
+    (:smalldatetime  (format nil "convert(varchar(30), [~a], 126)" name))
+    (:date           (format nil "convert(varchar(30), [~a], 126)" name))
     (:bigint         (format nil "cast([~a] as numeric)" name))
     (t               (format nil "[~a]" name))))
 


### PR DESCRIPTION
To solve #976 (as far as I tested)

Beware of CONVERT(varchar...). In mssql, the varchar default size is 30 in a cast.
Good practice is to dimension it explicitely. Not enough here for datetimeoffset (cast to 32 chars) so the varchar size needs to be explicitely set.