### PR TITLE
Implement tables row count ordering for MySQL.

### DIFF
--- a/src/load/copy-data.lisp
+++ b/src/load/copy-data.lisp
@@ -9,6 +9,11 @@
 (defmethod queue-raw-data ((copy copy) rawq concurrency)
   "Stream data as read by the map-queue method on the COPY argument into QUEUE,
    as given."
+  (log-message :notice "COPY ~a ~@[with ~d rows estimated~] [~a/~a]"
+               (format-table-name (target copy))
+               (table-row-count-estimate (target copy))
+               (lp:kernel-worker-index)
+               (lp:kernel-worker-count))
   (log-message :debug "Reader started for ~a" (format-table-name (target copy)))
   (let* ((start-time (get-internal-real-time))
          (row-count 0)
@@ -93,7 +98,6 @@
                              (trivial-backtrace:print-backtrace condition
                                                                 :output nil))
                 (lp::invoke-transfer-error condition))))
-        (log-message :notice "COPY ~a" table-name)
 
         ;; Check for Read Concurrency Support from our source
         (when (and multiple-readers (< 1 concurrency))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -96,6 +96,7 @@
            #:table-comment
            #:table-storage-parameter-list
            #:table-tablespace
+           #:table-row-count-estimate
            #:table-field-list
            #:table-column-list
            #:table-index-list

--- a/src/sources/common/api.lisp
+++ b/src/sources/common/api.lisp
@@ -153,6 +153,9 @@
 (defgeneric fetch-foreign-keys (catalog db-copy &key including excluding)
   (:documentation "Get the list of foreign keys from the source database."))
 
+(defgeneric fetch-table-row-count (catalog db-copy &key including excluding)
+  (:documentation "Get the estimate row count for tables in the source database"))
+
 (defgeneric fetch-comments (catalog db-copy &key including excluding)
   (:documentation "Get the list of comments from the source database."))
 

--- a/src/sources/common/api.lisp
+++ b/src/sources/common/api.lisp
@@ -154,7 +154,7 @@
   (:documentation "Get the list of foreign keys from the source database."))
 
 (defgeneric fetch-table-row-count (catalog db-copy &key including excluding)
-  (:documentation "Get the estimate row count for tables in the source database"))
+  (:documentation "Retrieve and set the row count estimate for given tables."))
 
 (defgeneric fetch-comments (catalog db-copy &key including excluding)
   (:documentation "Get the list of comments from the source database."))

--- a/src/sources/mysql/mysql-schema.lisp
+++ b/src/sources/mysql/mysql-schema.lisp
@@ -163,7 +163,7 @@
                                   &key
                                     including
                                     excluding)
-  "Get the row count estimate for given MySQL tables."
+  "Retrieve and set the row count estimate for given MySQL tables."
   (loop
      :for (table-name count)
      :in (mysql-query (sql "/mysql/list-table-rows.sql"

--- a/src/sources/mysql/mysql-schema.lisp
+++ b/src/sources/mysql/mysql-schema.lisp
@@ -155,6 +155,27 @@
      :finally
      (return schema)))
 
+;;;
+;;; MySQL table row count estimate
+;;;
+(defmethod fetch-table-row-count ((schema schema)
+                                  (mysql copy-mysql)
+                                  &key
+                                    including
+                                    excluding)
+  "Get the row count estimate for given MySQL tables."
+  (loop
+     :for (table-name count)
+     :in (mysql-query (sql "/mysql/list-table-rows.sql"
+                           (db-name *connection*)
+                           including    ; do we print the clause?
+                           including
+                           excluding    ; do we print the clause?
+                           excluding))
+     :do (let* ((table  (find-table schema table-name)))
+           (when table
+             (setf (table-row-count-estimate table) (parse-integer count))))))
+
 
 ;;;
 ;;; Queries to get the MySQL comments.

--- a/src/sources/mysql/mysql.lisp
+++ b/src/sources/mysql/mysql.lisp
@@ -165,6 +165,11 @@ Illegal ~a character starting at position ~a~@[: ~a~].~%"
                        :including including
                        :excluding excluding)
 
+        ;; fetch tables row count estimate
+        (fetch-table-row-count schema mysql
+                               :including including
+                               :excluding excluding)
+
         ;; fetch view (and their columns) metadata, covering comments too
         (let* ((view-names (unless (eq :all materialize-views)
                              (mapcar #'matview-source-name materialize-views)))

--- a/src/sources/mysql/sql/list-table-rows.sql
+++ b/src/sources/mysql/sql/list-table-rows.sql
@@ -1,0 +1,12 @@
+-- params: db-name
+--         including
+--         filter-list-to-where-clause incuding
+--         excluding
+--         filter-list-to-where-clause excluding
+    SELECT table_name,
+           cast(data_length/avg_row_length as integer)
+      FROM information_schema.tables
+    WHERE     table_schema = '~a'
+          and table_type = 'BASE TABLE'
+         ~:[~*~;and (~{table_name ~a~^ or ~})~]
+         ~:[~*~;and (~{table_name ~a~^ and ~})~];

--- a/src/utils/catalog.lisp
+++ b/src/utils/catalog.lisp
@@ -48,7 +48,8 @@
            table-list view-list matview-list extension-list sqltype-list)
 
 (defstruct table source-name name schema oid comment
-           storage-parameter-list tablespace row-count-estimate
+           storage-parameter-list tablespace
+           (row-count-estimate 0 :type fixnum)
            ;; field is for SOURCE
            field-list
            ;; column is for TARGET

--- a/src/utils/catalog.lisp
+++ b/src/utils/catalog.lisp
@@ -48,11 +48,16 @@
            table-list view-list matview-list extension-list sqltype-list)
 
 (defstruct table source-name name schema oid comment
-           storage-parameter-list tablespace
+           storage-parameter-list tablespace row-count-estimate
            ;; field is for SOURCE
+           field-list
            ;; column is for TARGET
+           column-list
+           index-list
+           fkey-list
+           trigger-list
            ;; citus is an extra slot for citus support
-           field-list column-list index-list fkey-list trigger-list citus-rule)
+           citus-rule)
 
 (defstruct matview source-name name schema definition)
 


### PR DESCRIPTION
This should help optimize the duration of migrating databases with very big
tables and lots of smaller ones. It might be a little too naive as far as
the optimisation goes, while still being an improvement on the default
alphabetical one.

Fixes #1099.