### PR TITLE
Fix syntax error near `integer`, and value NIL 

### DIFF
--- a/src/sources/mysql/sql/list-table-rows.sql
+++ b/src/sources/mysql/sql/list-table-rows.sql
@@ -4,7 +4,7 @@
 --         excluding
 --         filter-list-to-where-clause excluding
     SELECT table_name,
-           cast(data_length/avg_row_length as integer)
+           cast(data_length/avg_row_length as unsigned)
       FROM information_schema.tables
     WHERE     table_schema = '~a'
           and table_type = 'BASE TABLE'

--- a/src/sources/mysql/sql/list-table-rows.sql
+++ b/src/sources/mysql/sql/list-table-rows.sql
@@ -4,7 +4,7 @@
 --         excluding
 --         filter-list-to-where-clause excluding
     SELECT table_name,
-           cast(data_length/avg_row_length as unsigned)
+           coalesce(cast(data_length/avg_row_length as unsigned), 0)
       FROM information_schema.tables
     WHERE     table_schema = '~a'
           and table_type = 'BASE TABLE'


### PR DESCRIPTION
Since `pgloader` @ 11970bbc, importing from MySQL 5.7 to Postgresql 11
with SSL triggers the following exception:

```
 You have an error in your SQL syntax; check the manual that corresponds
 to your MySQL server version for the right syntax to use near 'integer'
```

Rather than casting to `integer`, we should be casting to `unsigned`
or calling `floor(..)`.