### PR TITLE
Keep name casing for foreign keys on mssql

### DIFF
--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -146,7 +146,7 @@
                 (col-name  (apply-identifier-case col))
                 (fcol-name (apply-identifier-case fcol))
                 (pg-fkey
-                 (make-fkey :name fkey-name
+                 (make-fkey :name (apply-identifier-case fkey-name)
                             :table table
                             :columns nil
                             :foreign-table ftable


### PR DESCRIPTION
It solves https://github.com/dimitri/pgloader/issues/1144