### PR TITLE
Add MySQL unsigned int casting rules

### DIFF
--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -64,7 +64,12 @@
              :target (:type "integer"  :drop-typemod t))
     (:source (:type "integer" :unsigned t)
              :target (:type "bigint"  :drop-typemod t))
-
+    (:source (:type "int" :unsigned t)
+             :target (:type "bigint"  :drop-typemod t))
+    
+    (:source (:type "int" :unsigned t :auto-increment t)
+              :target (:type "bigserial" :drop-typemod t))
+    
     ;; we need the following to benefit from :drop-typemod
     (:source (:type "tinyint")   :target (:type "smallint" :drop-typemod t))
     (:source (:type "smallint")  :target (:type "smallint" :drop-typemod t))


### PR DESCRIPTION
Fixes dimitri/pgloader#1186

Please comment if you think `(:source (:type "int" :unsigned t)` should be `(:source (:type "int" :unsigned t :auto-increment nil)` instead, and I can fix it.

However, the current version passed all tests I did with ints.