### PR TITLE
Fix ranged load from MySQL does not load the last record.

### DIFF
--- a/src/sources/mysql/mysql.lisp
+++ b/src/sources/mysql/mysql.lisp
@@ -32,7 +32,7 @@
           (let* ((col (mysql-column-name
                        (nth (position coldef (table-column-list (target mysql)))
                             (fields mysql))))
-                 (sql (format nil "select min(`~a`), max(`~a`) from `~a`"
+                 (sql (format nil "select min(`~a`), max(`~a`) + 1 from `~a`"
                               col col (table-source-name (source mysql)))))
             (destructuring-bind (min max)
                 (let ((result (first (mysql-query sql))))


### PR DESCRIPTION
#### Problem

I tried to load MySQL tables into PostgreSQL with `rows per range` option. The following is full `with` options.

```
WITH workers = 8, concurrency = 2, multiple readers per thread, rows per range = 50000, batch rows = 10000, prefetch rows = 10000
```

But at some tables, the last record was not copied to PostgreSQL.

#### Cause

where clause for ranged load seems to ignore the last record (or the record has max primary key).

https://github.com/dimitri/pgloader/blob/9788cc64ee8014f670e0d34c853b86c82693c9ec/src/sources/mysql/mysql.lisp#L120


Thank you for checking my pull request.