### PR TITLE
  Fix the header "On error stop / On error resume next"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -156,10 +156,11 @@ Repeatable (DROP+CREATE)
     `Continuous Migration <https://pgloader.io/blog/continuous-migration/>`_
     methodology for more details about the approach.
 
-On error stop / On error resume next The default behavior of pgloader when
-    migrating from a database is ``on error stop``. The idea is to let the
-    user fix either the migration specifications or the source data, and run
-    the process again, until it works.
+On error stop / On error resume next
+    The default behavior of pgloader when migrating from a database is 
+    ``on error stop``. The idea is to let the user fix either the migration 
+    specifications or the source data, and run the process again, until 
+    it works.
 
     In some cases the source data is so damaged as to be impossible to
     migrate in full, and it might be necessary to then resort to the ``on


### PR DESCRIPTION
The header "On error stop / On error resume next" contains some text that should be in the paragraph instead.