### PR TITLE
Fix reading from read-only databases with recent versions of postmodern

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -438,6 +438,7 @@
            #:pgconn-major-version
            #:pgconn-variant
            #:with-pgsql-transaction
+           #:with-pgsql-transaction-read
 	   #:with-pgsql-connection
 	   #:pgsql-execute
 	   #:pgsql-execute-with-timing
@@ -634,6 +635,7 @@
   (:import-from #:alexandria #:read-file-into-string)
   (:import-from #:pgloader.pgsql
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute)
   (:export #:read-ini-file
 	   #:parse-ini-file
@@ -702,6 +704,7 @@
         #:pgloader.sources)
   (:import-from #:pgloader.pgsql
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute
 		#:pgsql-execute-with-timing
 		#:create-tables
@@ -717,6 +720,7 @@
         #:pgloader.sources)
   (:import-from #:pgloader.pgsql
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute
 		#:pgsql-execute-with-timing
 		#:create-tables
@@ -736,6 +740,7 @@
   (:import-from #:pgloader.pgsql
 		#:with-pgsql-connection
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute
 		#:pgsql-execute-with-timing
 		#:list-table-oids
@@ -769,6 +774,7 @@
   (:import-from #:pgloader.transforms #:precision #:scale)
   (:import-from #:pgloader.pgsql
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute
 		#:pgsql-execute-with-timing
 		#:create-tables
@@ -788,6 +794,7 @@
   (:import-from #:pgloader.pgsql
 		#:with-pgsql-connection
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute
 		#:pgsql-execute-with-timing
 		#:pgsql-connect-and-execute-with-timing
@@ -812,6 +819,7 @@
   (:use #:cl #:pgloader.params #:pgloader.utils)
   (:import-from #:pgloader.pgsql
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute)
   (:export #:stream-messages
 	   #:start-syslog-server
@@ -836,6 +844,7 @@
   (:import-from #:pgloader.pgsql
                 #:pgsql-connection
 		#:with-pgsql-transaction
+		#:with-pgsql-transaction-read
 		#:pgsql-execute
                 #:pgconn-use-ssl
                 #:pgconn-table-name

--- a/src/pgsql/connection.lisp
+++ b/src/pgsql/connection.lisp
@@ -224,6 +224,21 @@
            (log-message :debug "BEGIN")
            ,@forms))))
 
+(defmacro with-pgsql-transaction-read ((&key pgconn database) &body forms)
+  "Run FORMS within a PostgreSQL transaction to DBNAME, reusing DATABASE if
+   given. Uses READ COMMITTED READ ONLY isolation level"
+  (if database
+      `(let ((pomo:*database* ,database))
+     (handling-pgsql-notices
+              (pomo:with-transaction (:read-committed-ro)
+                (log-message :debug "BEGIN")
+                ,@forms)))
+      ;; no database given, create a new database connection
+      `(with-pgsql-connection (,pgconn)
+         (pomo:with-transaction (:read-committed-ro)
+           (log-message :debug "BEGIN")
+           ,@forms))))
+
 (defmacro with-pgsql-connection ((pgconn) &body forms)
   "Run FROMS within a PostgreSQL connection to DBNAME. To get the connection
    spec from the DBNAME, use `get-connection-spec'."

--- a/src/sources/pgsql/pgsql.lisp
+++ b/src/sources/pgsql/pgsql.lisp
@@ -67,7 +67,7 @@
                           :use-result-as-rows t
                           :use-result-as-read t
                           :section :pre)
-    (with-pgsql-transaction (:pgconn (source-db pgsql))
+    (with-pgsql-transaction-read (:pgconn (source-db pgsql))
       (let ((variant   (pgconn-variant (source-db pgsql)))
             (pgversion (pgconn-major-version (source-db pgsql))))
         ;;
@@ -124,5 +124,5 @@
    need to clean-up any view created in the source PostgreSQL connection for
    the migration purpose."
   (when materialize-views
-    (with-pgsql-transaction (:pgconn  (source-db pgsql))
+    (with-pgsql-transaction-read (:pgconn (source-db pgsql))
       (drop-matviews materialize-views pgsql))))


### PR DESCRIPTION
Currently copying from read-only databases breaks with recent-enough version of the postmodern library.

https://github.com/marijnh/Postmodern/pull/163 changes the default transaction syntax from `BEGIN` to `BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED READ WRITE` (which corresponds to `read-committed-rw` in postmodern). This PR changes the isolation level to `read-committed-ro` for read operations.