### PR TITLE
parameterize DYNSIZE in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,11 @@ FROM debian:stable-slim as builder
 
   COPY ./ /opt/src/pgloader
 
+ARG DYNSIZE=4096
+
   RUN mkdir -p /opt/src/pgloader/build/bin \
       && cd /opt/src/pgloader \
-      && make clones save
+      && make DYNSIZE=$DYNSIZE clones save
 
 FROM debian:stable-slim
 

--- a/Dockerfile.ccl
+++ b/Dockerfile.ccl
@@ -27,9 +27,11 @@ FROM debian:stable-slim as builder
 
   COPY ./ /opt/src/pgloader
 
+ARG DYNSIZE=256
+
   RUN mkdir -p /opt/src/pgloader/build/bin \
       && cd /opt/src/pgloader \
-      && make CL=ccl DYNSIZE=256 clones save
+      && make CL=ccl DYNSIZE=$DYNSIZE clones save
 
 FROM debian:stable-slim
 


### PR DESCRIPTION
This just makes it easier to customise the build without having to fork. `DYNSIZE` is probably one of the most used parameters here that people want to easily change.