### PR TITLE
Added an autogenerated CI config [WIP]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@
         {
           "uses": "40ants/setup-lisp@v1",
           "with": {
-            "asdf-system": "pgloader-ci"
+            "asdf-system": "pgloader"
           }
         },
         {
@@ -38,7 +38,7 @@
         },
         {
           "name": "Run Linter",
-          "run": "qlot exec sblint pgloader-ci.asd pgloader.asd",
+          "run": "qlot exec sblint pgloader.asd",
           "shell": "bash"
         }
       ]
@@ -66,14 +66,14 @@
         {
           "uses": "40ants/setup-lisp@v1",
           "with": {
-            "asdf-system": "pgloader-ci",
+            "asdf-system": "pgloader",
             "qlfile-template": "{% ifequal quicklisp_dist \"ultralisp\" %}\ndist ultralisp http://dist.ultralisp.org\n{% endifequal %}\n\ngithub mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal"
           }
         },
         {
           "uses": "40ants/run-tests@v2",
           "with": {
-            "asdf-system": "pgloader-ci",
+            "asdf-system": "pgloader",
             "coveralls-token": "\n${{ matrix.lisp == 'sbcl-bin' &&\n    matrix.os == 'ubuntu-latest' &&\n    matrix.quicklisp-dist == 'ultralisp' &&\n    secrets.github_token }}"
           }
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+{
+  "name": "CI",
+  "on": {
+    "push": {
+      "branches": [
+        "master"
+      ]
+    },
+    "pull_request": null,
+    "schedule": [
+      {
+        "cron": "0 10 * * 1"
+      }
+    ]
+  },
+  "jobs": {
+    "linter": {
+      "runs-on": "ubuntu-latest",
+      "env": {
+        "OS": "ubuntu-latest",
+        "QUICKLISP_DIST": "quicklisp",
+        "LISP": "sbcl-bin"
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v1"
+        },
+        {
+          "uses": "40ants/setup-lisp@v1",
+          "with": {
+            "asdf-system": "pgloader-ci"
+          }
+        },
+        {
+          "name": "Install SBLint",
+          "run": "qlot exec ros install cxxxr/sblint",
+          "shell": "bash"
+        },
+        {
+          "name": "Run Linter",
+          "run": "qlot exec sblint pgloader-ci.asd pgloader.asd",
+          "shell": "bash"
+        }
+      ]
+    },
+    "run-tests": {
+      "strategy": {
+        "fail-fast": false,
+        "matrix": {
+          "os": [
+            "ubuntu-latest",
+            "macos-latest"
+          ]
+        }
+      },
+      "runs-on": "${{ matrix.os }}",
+      "env": {
+        "OS": "${{ matrix.os }}",
+        "QUICKLISP_DIST": "quicklisp",
+        "LISP": "sbcl-bin"
+      },
+      "steps": [
+        {
+          "uses": "actions/checkout@v1"
+        },
+        {
+          "uses": "40ants/setup-lisp@v1",
+          "with": {
+            "asdf-system": "pgloader-ci",
+            "qlfile-template": "{% ifequal quicklisp_dist \"ultralisp\" %}\ndist ultralisp http://dist.ultralisp.org\n{% endifequal %}\n\ngithub mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal"
+          }
+        },
+        {
+          "uses": "40ants/run-tests@v2",
+          "with": {
+            "asdf-system": "pgloader-ci",
+            "coveralls-token": "\n${{ matrix.lisp == 'sbcl-bin' &&\n    matrix.os == 'ubuntu-latest' &&\n    matrix.quicklisp-dist == 'ultralisp' &&\n    secrets.github_token }}"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/pgloader-ci.asd
+++ b/pgloader-ci.asd
@@ -1,0 +1,11 @@
+(asdf:defsystem #:pgloader-ci
+  :serial t
+  :description "CI Config for PostgreSQL"
+  :author "Dimitri Fontaine <dim@tapoueh.org>"
+  :license "The PostgreSQL Licence"
+  :depends-on (#:40ants-ci)
+  :components
+  ((:module "src"
+            :components
+            ((:file "ci")))))
+

--- a/src/ci.lisp
+++ b/src/ci.lisp
@@ -15,7 +15,10 @@
   :by-cron "0 10 * * 1"
   :on-pull-request t
   :cache t
-  :jobs ((linter)
+  :jobs ((linter
+          ;; When CI workflow defined in a separate non package-inferred
+          ;; package, we have to specify system to test manually.
+          :asd-system "pgloader")
          (run-tests
           :os ("ubuntu-latest"
                "macos-latest")
@@ -26,7 +29,9 @@
                  ;; "ccl-bin"
                  ;; "allegro"
                  )
-          
+
+
+          :asd-system "pgloader"
           :coverage t
           :qlfile "{% ifequal quicklisp_dist \"ultralisp\" %}
                    dist ultralisp http://dist.ultralisp.org

--- a/src/ci.lisp
+++ b/src/ci.lisp
@@ -1,0 +1,35 @@
+(defpackage #:pgloader-ci
+  (:use #:cl)
+  (:import-from #:40ants-ci/jobs/linter
+                #:linter)
+  (:import-from #:40ants-ci/jobs/run-tests
+                #:run-tests)
+  (:import-from #:40ants-ci/jobs/docs)
+  (:import-from #:40ants-ci/workflow
+                #:defworkflow))
+(in-package pgloader-ci)
+
+
+(defworkflow ci
+  :on-push-to "master"
+  :by-cron "0 10 * * 1"
+  :on-pull-request t
+  :cache t
+  :jobs ((linter)
+         (run-tests
+          :os ("ubuntu-latest"
+               "macos-latest")
+          :quicklisp ("quicklisp"
+                      ;; "ultralisp"
+                      )
+          :lisp ("sbcl-bin"
+                 ;; "ccl-bin"
+                 ;; "allegro"
+                 )
+          
+          :coverage t
+          :qlfile "{% ifequal quicklisp_dist \"ultralisp\" %}
+                   dist ultralisp http://dist.ultralisp.org
+                   {% endifequal %}
+
+                   github mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal")))


### PR DESCRIPTION
It uses https://github.com/40ants/ci workflow generator.

Here is how to use it from the REPL, to update configs:

```
CL-USER> (ql:quickload :pgloader-ci)
To load "pgloader-ci":
  Load 1 ASDF system:
    pgloader-ci
; Loading "pgloader-ci"
[package 40ants-ci/jobs/run-tests]................
[package 40ants-ci/ci]............................
[package pgloader-ci]
(:PGLOADER-CI)

CL-USER> (40ants-ci:generate :pgloader-ci)
(#P"/Users/art/projects/lisp/pgloader/.github/workflows/ci.yml")
```