### PR TITLE
Fix documentation typo: FILENAMES MATCHING

### DIFF
--- a/docs/ref/csv.rst
+++ b/docs/ref/csv.rst
@@ -46,7 +46,7 @@ following special values:
 
     Reads the data from the standard input stream.
 
-  - *FILENAMES MATCHING*
+  - *FILENAME MATCHING*
 
     The whole *matching* clause must follow the following rule::
 


### PR DESCRIPTION
CSV Source Specification: From
One of special values are `FILENAME MATCHING` and not `FILENAMES MATCHING`