### PR TITLE
Only select dependencies in the pg_class catalog

### DIFF
--- a/src/pgsql/sql/list-all-fkeys.sql
+++ b/src/pgsql/sql/list-all-fkeys.sql
@@ -29,6 +29,7 @@
         JOIN pg_class cf on r.confrelid = cf.oid
         JOIN pg_namespace nf on cf.relnamespace = nf.oid
         JOIN pg_depend d on d.classid = 'pg_constraint'::regclass
+                        and d.refclassid = 'pg_class'::regclass
                         and d.objid = r.oid
                         and d.refobjsubid = 0
    where r.contype = 'f'


### PR DESCRIPTION
This makes sure we do not select dependencies form the pg_operator class or other similar things.
Otherwise, if your FK has a dependency on something like a `pg_operator` (e.g., when your FK is pointing to a `CITEXT` column), things will break with the message:

```
ERROR pgsql: The value
         NIL
       is not of type
         PGLOADER.CATALOG:INDEX
```

during `PGLOADER.PGSQL:LIST-ALL-FKEYS`.

I'm not an expert on the exact contents on the `pg_class` and `pg_depend` tables, so can't guarantee this is the 100% correct fix.

Fixes dimitri/pgloader#1289