### PR TITLE
MS SQL: allow multiple table and schema excluding rules to be processed correctly

### DIFF
--- a/src/sources/mssql/sql/list-all-columns.sql
+++ b/src/sources/mssql/sql/list-all-columns.sql
@@ -45,6 +45,6 @@
    where     c.TABLE_CATALOG = '~a'
          and t.TABLE_TYPE = '~a'
          ~:[~*~;and (~{~a~^~&~10t or ~})~]
-         ~:[~*~;and (~{~a~^~&~10t and ~})~]
+         ~:[~*~;and (~{~a~^~&~10t or ~})~]
 
 order by c.table_schema, c.table_name, c.ordinal_position;


### PR DESCRIPTION
This allows multiple `excluding table names like 'TABLE' in schema 'SCHEMA'` rules to be provided in the load file when parsing data from and MS SQL database.

The following rule is already being processed correctly and won't change with this PR:
```
excluding table names like 'SomeTable' in schema 'dbo'
```
This commit allows the following rules to be processed correctly as well:
```
excluding table names like 'SomeTable' in schema 'dbo'
excluding table names like 'AnotherTable' in schema 'dbo'
excluding table names like 'SomeTable' in schema 'otherdbo'
```

Fixed #1328 