### PR TITLE
Add openssl-devel dependency to pgloader.spec

### DIFF
--- a/pgloader.spec
+++ b/pgloader.spec
@@ -9,9 +9,11 @@ Source0:            %{url}/archive/v%{version}.tar.gz
 
 BuildRequires: sbcl
 BuildRequires: freetds-devel
+BuildRequires: openssl-devel
 BuildRequires: sqlite-devel
 BuildRequires: zlib-devel
 Requires: freetds
+Requires: openssl-devel
 Requires: sbcl
 Requires: zlib
 Requires: sqlite


### PR DESCRIPTION
This works around a bug introduced by `cl+ssl-20211020-git.tgz` and "fixes" #1338

Unfortunately we have to make `openssl-devel` a runtime dependency to get around this bug. I think I would be preferable to use a version of cl+ssl which would be happy with `libcrypto.so.10`