### PR TITLE
Force libcrypto reload in src/hooks.lisp

### DIFF
--- a/src/hooks.lisp
+++ b/src/hooks.lisp
@@ -24,6 +24,7 @@
   "Close Foreign libs in use by pgloader at application save time."
   (let (#+sbcl (sb-ext:*muffled-warnings* 'style-warning))
     (mapc #'cffi:close-foreign-library '(cl+ssl::libssl
+                                         cl+ssl::libcrypto
                                          mssql::sybdb))))
 
 (defun open-foreign-libs ()


### PR DESCRIPTION
cl+ssl::libcrypto is also read at startup. If not properly closed in the
hooks, together with libssl, libcrypto will be loaded at startup and if
the first cl+ssl file alternative fails, the debugger is invoked.

* Fixes #1370