### PR TITLE
Allow underscores in cast type names

### DIFF
--- a/src/parsers/command-cast-rules.lisp
+++ b/src/parsers/command-cast-rules.lisp
@@ -27,7 +27,8 @@
 (defrule cast-type-name (or double-quoted-namestring
                             (and (alpha-char-p character)
                                  (* (or (alpha-char-p character)
-                                        (digit-char-p character)))))
+                                        (digit-char-p character)
+                                        #\_))))
   (:text t))
 
 (defrule cast-source-type (and kw-type cast-type-name)


### PR DESCRIPTION
Underscores might exist in cast type names, for example if the type being cast is an enum (which can have arbitrary names).

Fixes #1378