### PR TITLE
SBCL compiler notes should not be fatal to pgloader.

### DIFF
--- a/src/api.lisp
+++ b/src/api.lisp
@@ -158,15 +158,13 @@ Parameters here are meant to be already parsed, see parse-cli-optargs."
               (function (list source))
 
               (list     (list
-                         (let (notes)
-                           (multiple-value-bind (function warnings-p failure-p)
-                               (handler-case
-                                   (compile nil source)
-                                 (condition (c) (setf notes c)))
-                             (cond
-                               ((and failure-p notes) (signal notes))
-                               (warnings-p            function)
-                               (t                     function))))))
+                         (multiple-value-bind (function warnings-p failure-p)
+                             (compile nil source)
+                           (cond
+                             (failure-p   (error "Failed to compile code: ~a"
+                                                 source))
+                             (warnings-p  function)
+                             (t           function)))))
 
               (pathname (mapcar (lambda (expr) (compile nil expr))
                                 (parse-commands-from-file source)))

--- a/src/api.lisp
+++ b/src/api.lisp
@@ -157,7 +157,13 @@ Parameters here are meant to be already parsed, see parse-cli-optargs."
             (typecase source
               (function (list source))
 
-              (list     (list (compile nil source)))
+              (list     (list
+                         (let (c)
+                           (multiple-value-bind (function warnings-p failure-p)
+                               (handler-case
+                                   (compile nil source)
+                                 (condition (setf c condition)))
+                             (if (and failure-p c) (signal c) function)))))
 
               (pathname (mapcar (lambda (expr) (compile nil expr))
                                 (parse-commands-from-file source)))

--- a/src/api.lisp
+++ b/src/api.lisp
@@ -158,12 +158,15 @@ Parameters here are meant to be already parsed, see parse-cli-optargs."
               (function (list source))
 
               (list     (list
-                         (let (c)
+                         (let (notes)
                            (multiple-value-bind (function warnings-p failure-p)
                                (handler-case
                                    (compile nil source)
-                                 (condition (setf c condition)))
-                             (if (and failure-p c) (signal c) function)))))
+                                 (condition (c) (setf notes c)))
+                             (cond
+                               ((and failure-p notes) (signal notes))
+                               (warnings-p            function)
+                               (nil                   function))))))
 
               (pathname (mapcar (lambda (expr) (compile nil expr))
                                 (parse-commands-from-file source)))

--- a/src/api.lisp
+++ b/src/api.lisp
@@ -158,24 +158,24 @@ Parameters here are meant to be already parsed, see parse-cli-optargs."
               (function (list source))
 
               (list     (list
-                         (let (fun notes)
-                           (multiple-value-bind (function warnings-p failure-p)
-                               ;; capture the compiler notes and warnings
-                               (setf notes
-                                     (with-output-to-string (stream)
-                                       (with-compilation-unit (:override t)
-                                         (let ((*standard-output* stream)
-                                               (*error-output* stream)
-                                               (*trace-output* stream))
-                                           (setf fun (compile nil source))))))
-                             (when (and notes (string/= notes ""))
+                         ;; capture the compiler notes and warnings
+                         (let (function warnings-p failure-p notes)
+                           (setf notes
+                                 (with-output-to-string (stream)
+                                   (with-compilation-unit (:override t)
+                                     (let ((*standard-output* stream)
+                                           (*error-output* stream)
+                                           (*trace-output* stream))
+                                       (setf (values function warnings-p failure-p)
+                                             (compile nil source))))))
+                           (when (and notes (string/= notes ""))
                                (log-message :debug "~a" notes))
                              (cond
                                (failure-p   (error
                                              "Failed to compile code: ~a~%~a"
                                              source notes))
                                (warnings-p  function)
-                               (t           function))))))
+                               (t           function)))))
 
               (pathname (mapcar (lambda (expr) (compile nil expr))
                                 (parse-commands-from-file source)))

--- a/src/api.lisp
+++ b/src/api.lisp
@@ -166,7 +166,7 @@ Parameters here are meant to be already parsed, see parse-cli-optargs."
                              (cond
                                ((and failure-p notes) (signal notes))
                                (warnings-p            function)
-                               (nil                   function))))))
+                               (t                     function))))))
 
               (pathname (mapcar (lambda (expr) (compile nil expr))
                                 (parse-commands-from-file source)))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -315,16 +315,16 @@
                 ;; meaningful backtrace to the user in case of unexpected
                 ;; conditions being signaled.
                 (handler-bind
-                    (((and condition (not (or monitor-error
-                                              cli-parsing-error
-                                              source-definition-error
-                                              regression-test-error)))
-                      #'(lambda (condition)
-                          (format *error-output* "KABOOM!~%")
-                          (format *error-output* "~a: ~a~%~a~%~%"
-                                  (class-name (class-of condition))
-                                  condition
-                                  (print-backtrace condition debug)))))
+                    (((and serious-condition (not (or monitor-error
+                                                      cli-parsing-error
+                                                      source-definition-error
+                                                      regression-test-error)))
+                       #'(lambda (condition)
+                           (format *error-output* "KABOOM!~%")
+                           (format *error-output* "~a: ~a~%~a~%~%"
+                                   (class-name (class-of condition))
+                                   condition
+                                   (print-backtrace condition debug)))))
 
                   (with-monitor ()
                     ;; tell the user where to look for interesting things

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -321,7 +321,8 @@
                                               regression-test-error)))
                       #'(lambda (condition)
                           (format *error-output* "KABOOM!~%")
-                          (format *error-output* "FATAL error: ~a~%~a~%~%"
+                          (format *error-output* "~a: ~a~%~a~%~%"
+                                  (class-name (class-of condition))
                                   condition
                                   (print-backtrace condition debug)))))
 
@@ -385,7 +386,7 @@
                 (format *error-output* "~a~%" c)
                 (uiop:quit +os-code-error+))
 
-              (condition (c)
+              (serious-condition (c)
                 (format *error-output* "~%What I am doing here?~%~%")
                 (format *error-output* "~a~%~%" c)
                 (uiop:quit +os-code-error+)))))


### PR DESCRIPTION
The compile function returns warnings-p and failure-p values, use that to
decide if the code could be compiled, and only signal a condition when it
has been fatal to compiling the code at run-time.

The SBCL compiler is getting smarter at removing unreachable code, and it
looks like pgloader is producing some unreachable code from parsing the user
provided commands.

Fixes #1407 