### PR TITLE
Use the unix-namestring as the hash key for SQL queries.

### DIFF
--- a/src/utils/queries.lisp
+++ b/src/utils/queries.lisp
@@ -20,7 +20,7 @@
   "Transform given PATHNAME into an URL at which to serve it within URL-PATH."
   (multiple-value-bind (flag path-list last-component file-namestring-p)
       (uiop:split-unix-namestring-directory-components
-       (uiop:native-namestring
+       (uiop:unix-namestring
         (uiop:enough-pathname pathname root)))
     (declare (ignore flag file-namestring-p))
     ;;


### PR DESCRIPTION
The way we manage and then fetch the SQL queries embedded in the pgloader
binary we should really take the unix-namestring rather than the
native-namestring. Of course, this only matters when the host OS is NOT
unix, which is why this bug existed for so long.

Fixes #1418.