### PR TITLE
Accept that sometimes the Postgres source connection has a nil variant.

### DIFF
--- a/src/pgsql/pgsql-finalize-catalogs.lisp
+++ b/src/pgsql/pgsql-finalize-catalogs.lisp
@@ -43,6 +43,12 @@
   catalog)
 
 ;;;
+;;; Accept that sometimes the variant hasn't been specified at all.
+;;;
+(defmethod adjust-data-types ((catalog catalog) (variant (eql nil)))
+  catalog)
+
+;;;
 ;;; The RedShift case is a little more involved, as shown in their
 ;;; documentation:
 ;;;


### PR DESCRIPTION
In that case we behave the same as when the variant is known to be :pgdg.
The only other supported variant at this time being :redshift, that should
be okay.

Fixes #1421