### PR TITLE
Added support for sequences with minvalue defined

### DIFF
--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -408,7 +408,8 @@ BEGIN
                || trim(trailing ')'
                   from replace(pg_get_expr(d.adbin, d.adrelid),
                                'nextval', 'setval'))
-               || ', (select greatest(max(' || quote_ident(a.attname) || '), 1) from only '
+               || ', (select greatest(max(' || quote_ident(a.attname) || '), (select seqmin from pg_sequence where seqrelid = ('''
+               || pg_get_serial_sequence(quote_ident(nspname) || '.' || quote_ident(relname), quote_ident(a.attname)) || ''')::regclass limit 1), 1) from only '
                || quote_ident(nspname) || '.' || quote_ident(relname) || '));' as sql
          FROM pg_class c
               JOIN pg_namespace n on n.oid = c.relnamespace


### PR DESCRIPTION
When a sequence is defined with a minimum value, and the sequence to migrate is empty, the setval fails due to 1 being the default (which may be lower than the defined minimum value)