### PR TITLE
Add default support for MSSQL auto-incrementing bigint and smallint

### DIFF
--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -14,6 +14,12 @@
 
     (:source (:type "int" :auto-increment t)
              :target (:type "bigserial" :drop-default t))
+    
+    (:source (:type "bigint" :auto-increment t)
+             :target (:type "bigserial")
+
+    (:source (:type "smallint" :auto-increment t)
+             :target (:type "smallserial"))
 
     (:source (:type "tinyint") :target (:type "smallint"))
 


### PR DESCRIPTION
The current default rules do not create sequences for bigint or smallint identity columns in MSSQL.  The proposed changes add this behavior to the default rules by casting to bigserial and smallserial, respectively.  Please consider including in a subsequent release.  Thank you Dimitri, for your effort on this project!