### PR TITLE
Handle non-standard schemas when looking up identity column

### DIFF
--- a/src/sources/mssql/sql/list-all-columns.sql
+++ b/src/sources/mssql/sql/list-all-columns.sql
@@ -28,7 +28,7 @@
          ELSE c.COLUMN_DEFAULT
          END,
          c.IS_NULLABLE,
-         COLUMNPROPERTY(object_id(c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity'),
+         COLUMNPROPERTY(object_id(CONCAT(c.TABLE_SCHEMA, '.', c.TABLE_NAME)), c.COLUMN_NAME, 'IsIdentity'),
          c.CHARACTER_MAXIMUM_LENGTH,
          c.NUMERIC_PRECISION,
          c.NUMERIC_PRECISION_RADIX,


### PR DESCRIPTION
The current MSSQL implementation fails to find Identity columns in non-dbo schemas.

In list-all-columns.sql the query uses
``` 
object_id(c.TABLE_NAME)
```
which limits the scope of the object query to the primary schema (dbo).  Thus, when using an alternative schema the IsIdentity column always returns null.

The fix is to include the schema when querying for object_id which will work for both primary and secondary schemas.

```
object_id(CONCAT(c.TABLE_SCHEMA, '.', c.TABLE_NAME))
```