### PR TITLE
Fix mapping mysql signed int with auto_incement to postgresql serial (#1248)

### DIFF
--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -66,10 +66,12 @@
              :target (:type "bigint"  :drop-typemod t))
     (:source (:type "int" :unsigned t)
              :target (:type "bigint"  :drop-typemod t))
-    
+
     (:source (:type "int" :unsigned t :auto-increment t)
               :target (:type "bigserial" :drop-typemod t))
-    
+    (:source (:type "int" :signed t :auto-increment t)
+              :target (:type "serial" :drop-typemod t))
+
     ;; we need the following to benefit from :drop-typemod
     (:source (:type "tinyint")   :target (:type "smallint" :drop-typemod t))
     (:source (:type "smallint")  :target (:type "smallint" :drop-typemod t))


### PR DESCRIPTION
This is fix for #1248 
where is missing default cast for signed int without precision to serial in mysql
examples with problem are in that issue

it's coded by blind; i don't tested or compiled it