### PR TITLE
Fix Dockerfile build after new Debian release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as builder
+FROM debian:bookworm-slim as builder
 
   RUN apt-get update \
       && apt-get install -y --no-install-recommends \
@@ -9,7 +9,7 @@ FROM debian:stable-slim as builder
         gawk \
         git \
         libsqlite3-dev \
-        libssl1.1 \
+        libssl3 \
         libzip-dev \
         make \
         openssl \
@@ -30,7 +30,7 @@ ARG DYNSIZE=16384
       && cd /opt/src/pgloader \
       && make DYNSIZE=$DYNSIZE clones save
 
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
   RUN apt-get update \
       && apt-get install -y --no-install-recommends \

--- a/Dockerfile.ccl
+++ b/Dockerfile.ccl
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as builder
+FROM debian:bookworm-slim as builder
 
   RUN apt-get update \
       && apt-get install -y --no-install-recommends \
@@ -9,7 +9,7 @@ FROM debian:stable-slim as builder
         gawk \
         git \
         libsqlite3-dev \
-        libssl1.1 \
+        libssl3 \
         libzip-dev \
         make \
         openssl \
@@ -33,7 +33,7 @@ ARG DYNSIZE=256
       && cd /opt/src/pgloader \
       && make CL=ccl DYNSIZE=$DYNSIZE clones save
 
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 
   RUN apt-get update \
       && apt-get install -y --no-install-recommends \
@@ -41,7 +41,7 @@ FROM debian:stable-slim
         freetds-dev \
         gawk \
         libsqlite3-dev \
-        libssl1.1 \
+        libssl3 \
         libzip-dev \
         make \
         sbcl \


### PR DESCRIPTION
Building Docker container broke after Debian Bookwork release. This PR fixes the issue and pins Dockerfile to use Bookworm so that it doesn't break after next release.