### PR TITLE
fixing custom where clause issue when tables are selected with BIN2 collation

### DIFF
--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -124,12 +124,12 @@
   (loop
      :with incl-where := (filter-list-to-where-clause
                           mssql including :not nil
-                          :schema-col "kcu1.table_schema"
-                          :table-col "kcu1.table_name")
+                          :schema-col "KCU1.table_schema"
+                          :table-col "KCU1.table_name")
      :with excl-where := (filter-list-to-where-clause
                           mssql excluding :not t
-                          :schema-col "kcu1.table_schema"
-                          :table-col "kcu1.table_name")
+                          :schema-col "KCU1.table_schema"
+                          :table-col "KCU1.table_name")
      :for (fkey-name schema-name table-name col
                      fschema-name ftable-name fcol
                      fk-update-rule fk-delete-rule)


### PR DESCRIPTION


This is an extenstion to PR #653 
pgloader errors out while querying foreign keys when tables clause is used for SQL_Latin1_General_CP850_BIN2 collation (might exist for CS collation).  Code has been changed, built from source and tested successfully.