### PR TITLE
Fix "reset sequences" crash on tables with case sensitive column names

### DIFF
--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -409,7 +409,7 @@ BEGIN
                   from replace(pg_get_expr(d.adbin, d.adrelid),
                                'nextval', 'setval'))
                || ', (select greatest(max(' || quote_ident(a.attname) || '), (select seqmin from pg_sequence where seqrelid = ('''
-               || pg_get_serial_sequence(quote_ident(nspname) || '.' || quote_ident(relname), quote_ident(a.attname)) || ''')::regclass limit 1), 1) from only '
+               || pg_get_serial_sequence(quote_ident(nspname) || '.' || quote_ident(relname), a.attname) || ''')::regclass limit 1), 1) from only '
                || quote_ident(nspname) || '.' || quote_ident(relname) || '));' as sql
          FROM pg_class c
               JOIN pg_namespace n on n.oid = c.relnamespace


### PR DESCRIPTION
On case sensitive migrations (i.e. with "quote identifiers"), reset sequences fail with the following error. 

```
Database error 42703: column ""<columnName>"" of relation "<table>" does not exist
```

This is due to invalid parameters being passed to `pg_get_serial_sequence` function introduced in  e32066d35a03df3b386189d5c4e9dcd11805ee03

for example, on a mysql table with following definition

```SQL
CREATE TABLE botLog(
    `logID` bigint(20) NOT NULL AUTO_INCREMENT, 
    `message` varchar(255), 
    PRIMARY KEY (`logID`)
);
```

```SQL
SELECT pg_get_serial_sequence(quote_ident('public') || '.' || quote_ident('botLog'), quote_ident('logID'));
ERROR:  column ""logID"" of relation "botLog" does not exist
```
throws the same error, but the following works

```SQL
SELECT pg_get_serial_sequence(quote_ident('public') || '.' || quote_ident('botLog'), 'logID');
  pg_get_serial_sequence
---------------------------
 public."botLog_logID_seq"
 ```

ref: https://github.com/dimitri/pgloader/issues/425