### PR TITLE
fix(sqlite): respect case option for foreign keys

### DIFF
--- a/src/sources/sqlite/sqlite-schema.lisp
+++ b/src/sources/sqlite/sqlite-schema.lisp
@@ -241,8 +241,8 @@
                                   pg-fkey)))))
              (if (and fkey from to)
                  (progn
-                   (push-to-end from (fkey-columns fkey))
-                   (push-to-end to   (fkey-foreign-columns fkey)))
+                   (push-to-end (apply-identifier-case from) (fkey-columns fkey))
+                   (push-to-end (apply-identifier-case to)   (fkey-foreign-columns fkey)))
 
                  ;; it might be INCLUDING/EXCLUDING clauses that make it we
                  ;; don't have to care about the fkey definition, or it


### PR DESCRIPTION
When using the option "quote identifiers", I had errors ("column doesn't exist") when importing foreign keys constraints from sqlite to PG. This should fix the issue