### PR TITLE
Allow colon in dsn-dbname

### DIFF
--- a/src/parsers/command-db-uri.lisp
+++ b/src/parsers/command-db-uri.lisp
@@ -125,6 +125,7 @@
                                     (* (or (alpha-char-p character)
                                            (digit-char-p character)
                                            #\.
+					   #\:
                                            punct)))))
   (:lambda (dbn)
     (list :dbname (text (second dbn)))))


### PR DESCRIPTION
Xata uses a db:branch naming pattern for Postgres databases.