### PR TITLE
fix(mssql): IDENTITY columns not detected outside default schema

### DIFF
--- a/src/sources/mssql/sql/list-all-columns.sql
+++ b/src/sources/mssql/sql/list-all-columns.sql
@@ -30,7 +30,7 @@
          ELSE c.COLUMN_DEFAULT
          END,
          c.IS_NULLABLE,
-         COLUMNPROPERTY(object_id(c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity'),
+         COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity'),
          c.CHARACTER_MAXIMUM_LENGTH,
          c.NUMERIC_PRECISION,
          c.NUMERIC_PRECISION_RADIX,


### PR DESCRIPTION
Fixes dimitri/pgloader#1586