### PR TITLE
fix(mssql): int (32bit, auto-increment) cast to bigserial (64bit)

### DIFF
--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -13,7 +13,7 @@
     (:source (:type "xml")       :target (:type "xml" :drop-typemod t))
 
     (:source (:type "int" :auto-increment t)
-             :target (:type "bigserial" :drop-default t))
+             :target (:type "serial" :drop-default t))
     
     (:source (:type "bigint" :auto-increment t)
              :target (:type "bigserial"))


### PR DESCRIPTION
Cast SQL Server auto-incremented `int` (4 bytes) to PG `serial` (4 bytes).

Fixes: dimitri/pgloader#1590