### PR TITLE
fix (mssql): quote indexes whose names contain e.g. "-"

### DIFF
--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -98,7 +98,8 @@
                             incl-where
                             excl-where  ; do we print the clause?
                             excl-where))
-     :do (let* ((schema     (find-schema catalog schema-name))
+     :do (let* ((index-name (apply-identifier-case index-name))
+                (schema     (find-schema catalog schema-name))
                 (table      (find-table schema table-name))
                 (pg-index   (make-index :name index-name
                                         :schema schema


### PR DESCRIPTION
When moving data MSSQL -> Postgres indexes with names containing a dash gave errors.