### PR TITLE
also omit "DEFAULT NULL" when (eq (column-default column) :NULL)

### DIFF
--- a/src/pgsql/pgsql-ddl.lisp
+++ b/src/pgsql/pgsql-ddl.lisp
@@ -137,7 +137,7 @@
           (column-type-mod column)
           (column-type-mod column)
           (column-nullable column)
-          (column-default column)
+          (and (column-default column) (not (eq (column-default column) :NULL)))
           (format-default-value column)))
 
 (defvar *pgsql-default-values*


### PR DESCRIPTION
pgloader omits "DEFAULT NULL" clauses when (column-default column) is NIL. With this patch "DEFAULT NULL" clauses are also omitted when (column-default column) is :NULL.