### PR TITLE
Update Dockerfile.ccl to prevent the encoding problem when migrating from MSSQL

### DIFF
--- a/Dockerfile.ccl
+++ b/Dockerfile.ccl
@@ -50,4 +50,6 @@ FROM debian:bookworm-slim
 
   COPY --from=builder /opt/src/pgloader/build/bin/pgloader /usr/local/bin
 
+  ADD conf/freetds.conf /etc/freetds/freetds.conf
+
   LABEL maintainer="Dimitri Fontaine <dim@tapoueh.org>"


### PR DESCRIPTION
This PR is to update Dockerfile.ccl to prevent the encoding problem when migrating from MSSQL, same with what have already done in the normal Dockerfile with SBCL.