### PR TITLE
Install CA certificates on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ FROM debian:bookworm-slim
 
   RUN apt-get update \
       && apt-get install -y --no-install-recommends \
+        ca-certificates \
         curl \
         freetds-dev \
         gawk \
@@ -42,6 +43,7 @@ FROM debian:bookworm-slim
         make \
         sbcl \
         unzip \
+      && update-ca-certificates \
       && rm -rf /var/lib/apt/lists/*
 
   COPY --from=builder /opt/src/pgloader/build/bin/pgloader /usr/local/bin


### PR DESCRIPTION
Currently, we install ca-certificates package only on the builder, not on the docker image which is distributed to the user. Without CA certificates, we see errors like below,
```
2024-09-18T05:30:46.112001Z ERROR Connecting to PostgreSQL <host name>: SSL verify error: 20 X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
DB-CONNECTION-ERROR: Failed to connect to pgsql at "<host name>" (port 30025) as user "tsdbadmin": SSL verify error: 20 X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
An unhandled error condition has been signalled:
   Failed to connect to pgsql at "<host name>" (port 30025) as user "tsdbadmin": SSL verify error: 20 X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
```