### PR TITLE
Use latest cosign action to fix signing issue on docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,13 +36,15 @@ jobs:
         uses: actions/checkout@v2
         
 
-      # Install the cosign tool except on PR
+      # Install the cosign tool (not used on PR, still installed)
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v1.4.1
+        uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v1.4.1'
+          cosign-release: 'v2.2.3'
+
+      - name: Check cosign version
+        run: cosign version
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
@@ -88,8 +90,11 @@ jobs:
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: cosign sign ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
+        run: cosign sign --yes ${TAGS}
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          # should use @${{ steps.build-and-push.outputs.digest }}
+          # but that leads to "entity not found in registry"
+          COSIGN_EXPERIMENTAL: "true"


### PR DESCRIPTION
Adopts changes from pgcopydb https://github.com/dimitri/pgcopydb/blob/main/.github/workflows/docker-publish.yml