### PR TITLE
Remove rows per range option from Postgres-Postgres docs

### DIFF
--- a/docs/ref/pgsql.rst
+++ b/docs/ref/pgsql.rst
@@ -212,11 +212,6 @@ supported, and the default *WITH* clause is: *no truncate*, *create schema*,
     When this option is listed pgloader only issues the `COPY` statements,
     without doing any other processing.
 
-  - *rows per range*
-  
-    How many rows are fetched per `SELECT` query when using *multiple
-    readers per thread*, see above for details.
-
 PostgreSQL Database Casting Rules
 ---------------------------------
 


### PR DESCRIPTION
This was never implemented for pgsql<->pgsql migrations.

Fixes: #1550