### PR TITLE
Make docker stop emitting FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as builder
+FROM debian:bookworm-slim AS builder
 
   RUN apt-get update \
       && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
It’s really nothing, just preventing an annoying warning.