### PR TITLE
fix: remove batch concurrency support

### DIFF
--- a/src/parsers/command-options.lisp
+++ b/src/parsers/command-options.lisp
@@ -73,13 +73,10 @@
     (bind (((_ _ _ val) batch-size))
       (cons :batch-size val))))
 
-;;; deprecated, but still accept it in the parsing
-(defrule option-prefetch-rows (and (or (and kw-batch kw-concurrency)
-                                       (and kw-prefetch kw-rows))
-                                   equal-sign
+(defrule option-prefetch-rows (and kw-prefetch kw-rows equal-sign
                                    (+ (digit-char-p character)))
   (:lambda (prefetch-rows)
-    (bind (((_ _ nb) prefetch-rows))
+    (bind (((_ _ _ nb) prefetch-rows))
       (cons :prefetch-rows (parse-integer (text nb))))))
 
 (defrule option-rows-per-range (and kw-rows kw-per kw-range

--- a/test/csv-districts-env.load
+++ b/test/csv-districts-env.load
@@ -35,7 +35,6 @@ LOAD CSV
           skip header = 1,
           batch rows = 200,
           batch size = 1024 kB,
-          batch concurrency = 3,
           fields terminated by '\t'
 
    BEFORE LOAD DO

--- a/test/csv-districts-stdin.load
+++ b/test/csv-districts-stdin.load
@@ -30,7 +30,6 @@ LOAD CSV
           skip header = 1,
           batch rows = 200,
           batch size = 1024 kB,
-          batch concurrency = 3,
           fields terminated by '\t'
 
    BEFORE LOAD DO

--- a/test/csv-districts.load
+++ b/test/csv-districts.load
@@ -34,7 +34,6 @@ LOAD CSV
           skip header = 1,
           batch rows = 200,
           batch size = 1024 kB,
-          batch concurrency = 3,
           fields terminated by '\t'
 
    BEFORE LOAD DO


### PR DESCRIPTION
Fixes https://github.com/dimitri/pgloader/issues/1661

if `batch concurrency` option is specified, it'll override `prefetch rows`, since `batch concurrency` is deprecated, I dropped it.