### PR TITLE
Eliminate docker build casing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as builder
+FROM debian:bookworm-slim AS builder
 
   RUN apt-get update \
       && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
There is a small warning when building the Docker image. This small change fixes the warning.