### PR TITLE
Fix error with quote identifiers and uppercase identifiers

### DIFF
--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -409,7 +409,7 @@ BEGIN
                   from replace(pg_get_expr(d.adbin, d.adrelid),
                                'nextval', 'setval'))
                || ', (select greatest(max(' || quote_ident(a.attname) || '), (select seqmin from pg_sequence where seqrelid = ('''
-               || pg_get_serial_sequence(quote_ident(nspname) || '.' || quote_ident(relname), quote_ident(a.attname)) || ''')::regclass limit 1), 1) from only '
+               || pg_get_serial_sequence(quote_ident(nspname) || '.' || quote_ident(relname), a.attname) || ''')::regclass limit 1), 1) from only '
                || quote_ident(nspname) || '.' || quote_ident(relname) || '));' as sql
          FROM pg_class c
               JOIN pg_namespace n on n.oid = c.relnamespace


### PR DESCRIPTION
Fix fatal error when running with "quote identifiers" and the source has uppercase identifiers, as described in #1651. This PR simply contains the suggested fix from https://github.com/dimitri/pgloader/issues/1673#issuecomment-2930754447

Works for me, both with and without "quote identifiers", but I'm not familiar enough with pgloader to tell if it could have unintended consequences or if there is a better way.