### PR TITLE
Add verify-full to supported SSL modes for postgres

### DIFF
--- a/docs/command.rst
+++ b/docs/command.rst
@@ -245,7 +245,7 @@ Where:
     *user* and *password*.
 
     The *sslmode* parameter values can be one of `disable`, `allow`,
-    `prefer` or `require`.
+    `prefer`, `require` or `verify-full`.
 
     For backward compatibility reasons, it's possible to specify the
     *tablename* option directly, without spelling out the `tablename=`

--- a/src/parsers/command-db-uri.lisp
+++ b/src/parsers/command-db-uri.lisp
@@ -130,11 +130,13 @@
 (defrule dsn-option-ssl-allow   "allow"   (:constant :try))
 (defrule dsn-option-ssl-prefer  "prefer"  (:constant :try))
 (defrule dsn-option-ssl-require "require" (:constant :yes))
+(defrule dsn-option-ssl-verify-full "verify-full" (:constant :full))
 
 (defrule dsn-option-ssl (and "sslmode" "=" (or dsn-option-ssl-disable
                                                dsn-option-ssl-allow
                                                dsn-option-ssl-prefer
-                                               dsn-option-ssl-require))
+                                               dsn-option-ssl-require
+                                               dsn-option-ssl-verify-full))
   (:lambda (ssl)
     (destructuring-bind (key e val) ssl
       (declare (ignore key e))
@@ -274,4 +276,3 @@
   `((*pg-settings* (pgloader.pgsql:sanitize-user-gucs ',gucs))
     (*pgsql-reserved-keywords*
      (pgloader.pgsql:list-reserved-keywords ,pg-db-uri))))
-


### PR DESCRIPTION
I wanted to use the tool with databricks lakebase and it seems like pgloader doesn't support SNI with any of the existing `sslmode` values. 
Underlying `Postmodern` library [seem to support](https://marijnhaverbeke.nl/postmodern/#b5bb7222-8134-4dcb-83b7-f764b7f2bb33) SNI with mode set to `:full` and it looks like in the pgloader code only the parsing bits need to be fixed.

The only problem I see is that semantics are different from what `libpq` does. 
libpq sends SNI by default through the sslsni connection parameter, independently of the selected sslmode. In libpq, sslmode=require still uses TLS and sends SNI by default; sslmode=verify-full additionally verifies the server certificate hostname.
But cl-postgres from Postmodern [appears to pass](https://github.com/marijnh/Postmodern/blob/master/cl-postgres/protocol.lisp#L231) the hostname to the TLS layer only for the :full SSL mode.


Please take a look and let me know your thoughts.