### PR TITLE
fix: snake_case identifiers and core behaviour fixes (v4)

### DIFF
--- a/clojure/src/pgloader/cli.clj
+++ b/clojure/src/pgloader/cli.clj
@@ -348,11 +348,10 @@
               (core/run-command cmd opts))
             (do (println "No load file or source/target specified")
                 (print-usage))))
-        ;; Exit with code 1 when any rows were rejected or tables failed (#634).
-        ;; Checked after all commands complete so multi-file runs aggregate correctly.
-        (let [totals (stats/grand-totals)]
-          (when (pos? (:errs totals))
-            (System/exit 1)))))))
+        ;; Exit with code 1 when a fatal load error occurred (#634).
+        ;; Row-level rejections (type errors) do not count as fatal.
+        (when (stats/fatal-error?)
+          (System/exit 1))))))
 
 (defn -main
   "Main entry point for the JAR."

--- a/clojure/src/pgloader/cli.clj
+++ b/clojure/src/pgloader/cli.clj
@@ -5,7 +5,8 @@
             [pgloader.load-file.ast :as ast]
             [pgloader.core :as core]
             [pgloader.copy :as copy]
-            [pgloader.regress :as regress])
+            [pgloader.regress :as regress]
+            [pgloader.stats :as stats])
   (:import [java.net URI]
            [java.nio.charset Charset]
            [org.slf4j LoggerFactory]
@@ -346,7 +347,12 @@
             (let [cmd (build-inline-command (:source-uri opts) (:target-uri opts) opts)]
               (core/run-command cmd opts))
             (do (println "No load file or source/target specified")
-                (print-usage))))))))
+                (print-usage))))
+        ;; Exit with code 1 when any rows were rejected or tables failed (#634).
+        ;; Checked after all commands complete so multi-file runs aggregate correctly.
+        (let [totals (stats/grand-totals)]
+          (when (pos? (:errs totals))
+            (System/exit 1)))))))
 
 (defn -main
   "Main entry point for the JAR."

--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -607,6 +607,7 @@
                                   (log/error (str "Failed to create " schema "." table ": " (.getMessage e)))
                                   (stats/update-entry! :data table-label :errs 1)
                                   (reset! load-failed true)
+                                  (stats/fatal-error!)
                                   (swap! failed-tables conj table)))))
                           (stats/update-entry! :pre "Create tables"
                                                :rows (count cat)
@@ -745,6 +746,7 @@
                                                           (log/error e (str "Failed to copy table " schema "." table ": " (.getMessage e)))
                                                           (stats/update-entry! :data table-label :errs 1)
                                                           (reset! load-failed true)
+                                                          (stats/fatal-error!)
                                                           (when copy/*on-error-stop*
                                                             (log/error "ON ERROR STOP — aborting remaining tables")
                                                             (throw e)))

--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -503,367 +503,381 @@
                   (log/info (str "Processing tables in this order: "
                                  (clojure.string/join ", " (map :table-name cat))))
                   (log/info "Preparing target PostgreSQL schema")
-                  (let [failed-tables (atom #{})
-                        table-oids    (atom {})
-                        preserve-index-names? (get with-options :preserve-index-names false)
-                        create-indexes? (or (get with-options :create-indexes false)
-                                            (get with-options :reindex false))
-                        schema-only?  (get with-options :schema-only false)
+                  (let [load-failed (atom false)]
+                    (let [failed-tables (atom #{})
+                          table-oids    (atom {})
+                          preserve-index-names? (get with-options :preserve-index-names false)
+                          create-indexes? (or (get with-options :create-indexes false)
+                                              (get with-options :reindex false))
+                          schema-only?  (get with-options :schema-only false)
                 ;; workers: parallel table copies; default 4 for DB sources, 8 for file sources (v3 defaults)
-                        workers       (or (get with-options :workers)
-                                          (if (#{:mysql :mariadb :pgsql :mssql :sqlite} (:type source-uri)) 4 8))
+                          workers       (or (get with-options :workers)
+                                            (if (#{:mysql :mariadb :pgsql :mssql :sqlite} (:type source-uri)) 4 8))
                 ;; multiple readers per table: opt-in; concurrency = N readers per table
-                        multiple-readers? (get with-options :multiple-readers false)
-                        concurrency   (long (or (get with-options :concurrency) 1))
-                        chunk-bytes   (long (or (get with-options :chunk-size) (* 50 1024 1024)))
-                        all-idx-count (int (transduce (map #(count (:indexes %))) + 0 cat))
-                        max-par-idx   (int (max 1 (or (get with-options :max-parallel-create-index)
-                                                      all-idx-count)))
+                          multiple-readers? (get with-options :multiple-readers false)
+                          concurrency   (long (or (get with-options :concurrency) 1))
+                          chunk-bytes   (long (or (get with-options :chunk-size) (* 50 1024 1024)))
+                          all-idx-count (int (transduce (map #(count (:indexes %))) + 0 cat))
+                          max-par-idx   (int (max 1 (or (get with-options :max-parallel-create-index)
+                                                        all-idx-count)))
                 ;; Index executor: each table's indexes are submitted as soon as that
                 ;; table's COPY finishes, so index builds overlap with subsequent copies.
-                        idx-executor  (when (and create-indexes? (pos? all-idx-count))
-                                        (Executors/newFixedThreadPool max-par-idx))
-                        idx-futures   (atom [])
-                        idx-wall-t0   (atom nil)]
+                          idx-executor  (when (and create-indexes? (pos? all-idx-count))
+                                          (Executors/newFixedThreadPool max-par-idx))
+                          idx-futures   (atom [])
+                          idx-wall-t0   (atom nil)]
           ;; drop schema — executed once per schema before per-table DDL
-                    (when (and (get with-options :drop-schema false)
-                               (not (get with-options :data-only false)))
-                      (let [schemas (distinct (map #(or (:schema %) "public") cat))]
-                        (doseq [schema schemas]
-                          (log/info (str "Dropping schema " schema " CASCADE"))
-                          (try
-                            (jdbc/execute! pg-conn [(str "DROP SCHEMA IF EXISTS "
-                                                         (ddl/identifier-quote schema) " CASCADE")])
-                            (.commit pg-conn)
-                            (catch Exception e
-                              (.rollback pg-conn)
-                              (log/warn (str "Failed to drop schema " schema ": " (.getMessage e))))))))
+                      (when (and (get with-options :drop-schema false)
+                                 (not (get with-options :data-only false)))
+                        (let [schemas (distinct (map #(or (:schema %) "public") cat))]
+                          (doseq [schema schemas]
+                            (log/info (str "Dropping schema " schema " CASCADE"))
+                            (try
+                              (jdbc/execute! pg-conn [(str "DROP SCHEMA IF EXISTS "
+                                                           (ddl/identifier-quote schema) " CASCADE")])
+                              (.commit pg-conn)
+                              (catch Exception e
+                                (.rollback pg-conn)
+                                (log/warn (str "Failed to drop schema " schema ": " (.getMessage e))))))))
           ;; reindex — drop existing indexes before data load so they are rebuilt after
-                    (when (and (get with-options :reindex false)
-                               (not (get with-options :schema-only false)))
-                      (doseq [t cat]
-                        (let [schema (or (:schema t) "public")
-                              table  (:table-name t)]
-                          (when-let [idxs (seq (:indexes t))]
-                            (doseq [idx idxs]
-                              (let [idx-name (ddl/identifier-quote (:name idx))]
-                                (try
-                                  (jdbc/execute! pg-conn [(str "DROP INDEX IF EXISTS " idx-name)])
-                                  (.commit pg-conn)
-                                  (catch Exception _
-                                    (.rollback pg-conn)))))))))
+                      (when (and (get with-options :reindex false)
+                                 (not (get with-options :schema-only false)))
+                        (doseq [t cat]
+                          (let [schema (or (:schema t) "public")
+                                table  (:table-name t)]
+                            (when-let [idxs (seq (:indexes t))]
+                              (doseq [idx idxs]
+                                (let [idx-name (ddl/identifier-quote (:name idx))]
+                                  (try
+                                    (jdbc/execute! pg-conn [(str "DROP INDEX IF EXISTS " idx-name)])
+                                    (.commit pg-conn)
+                                    (catch Exception _
+                                      (.rollback pg-conn)))))))))
           ;; Phase 1: DDL for all tables — each table in its own transaction.
           ;; If a table's DDL fails, its transaction (including DROP TABLE)
           ;; is rolled back, leaving existing data intact.
            ;; Skip DDL if create-tables is false, create-no-tables, data-only
            ;; is set, or table already exists (e.g. created by BEFORE LOAD DO).
-                    (when (and (get with-options :create-tables false)
-                               (not (get with-options :create-no-tables false))
-                               (not (get with-options :data-only false)))
-                      (stats/new-entry! :pre "Create tables")
-                      (let [ddl-phase-start (System/nanoTime)]
-                        (doseq [[i t] (map-indexed vector cat)]
-                          (let [schema (or (:schema t) "public")
-                                table  (:table-name t)
-                                cols   (:columns t)
-                                table-label (table-stats-label schema table)]
-                            (stats/new-entry! :data table-label)
-                            (log/info (str "COPY " table " [" (inc i) "/" (count cat) "]"))
-                            (log/debug (str "Creating DDL for table: " schema "." table))
-                            (try
-                              (let [ddl-start (System/nanoTime)
-                                    pk (:primary-key t)
-                                    enum-types (:enum-types t)
-                                    ddl-sqls (cond-> [(str "CREATE SCHEMA IF NOT EXISTS " (ddl/identifier-quote schema))]
-                                               (not (get with-options :include-no-drop false))
-                                               (conj (ddl/drop-table-if-exists-sql schema table))
-                                               :always
-                                               (conj (ddl/create-table-sql schema table cols (:table-comment t))))]
-                  ;; Create ENUM/SET types before CREATE TABLE
-                                (when (seq enum-types)
-                                  (exec-post-ddl! pg-conn (ddl/create-enum-types-sql enum-types)
-                                                  (str "ENUM TYPES for " table)))
-                                (run-ddl-tx pg-conn ddl-sqls)
+                      (when (and (get with-options :create-tables false)
+                                 (not (get with-options :create-no-tables false))
+                                 (not (get with-options :data-only false)))
+                        (stats/new-entry! :pre "Create tables")
+                        (let [ddl-phase-start (System/nanoTime)]
+                          (doseq [[i t] (map-indexed vector cat)]
+                            (let [schema (or (:schema t) "public")
+                                  table  (:table-name t)
+                                  cols   (:columns t)
+                                  table-label (table-stats-label schema table)]
+                              (stats/new-entry! :data table-label)
+                              (log/info (str "COPY " table " [" (inc i) "/" (count cat) "]"))
+                              (log/debug (str "Creating DDL for table: " schema "." table))
+                              (try
+                                (let [ddl-start (System/nanoTime)
+                                      pk (:primary-key t)
+                                      enum-types (:enum-types t)
+                                      ddl-sqls (cond-> [(str "CREATE SCHEMA IF NOT EXISTS " (ddl/identifier-quote schema))]
+                                                 (not (get with-options :include-no-drop false))
+                                                 (conj (ddl/drop-table-if-exists-sql schema table))
+                                                 :always
+                                                 (conj (ddl/create-table-sql schema table cols (:table-comment t))))]
+                  ;; Create ENUM/SET types before CREATE TABLE.
+                  ;; With INCLUDE NO DROP, skip the DROP TYPE statements so
+                  ;; pre-existing types are preserved (#1001).
+                                  (when (seq enum-types)
+                                    (let [enum-sqls (ddl/create-enum-types-sql enum-types)
+                                          sqls-to-run (if (get with-options :include-no-drop false)
+                                                        (remove #(str/starts-with? % "DROP") enum-sqls)
+                                                        enum-sqls)]
+                                      (exec-post-ddl! pg-conn sqls-to-run
+                                                      (str "ENUM TYPES for " table))))
+                                  (run-ddl-tx pg-conn ddl-sqls)
                   ;; Query table OID and create primary-key index with idx_{oid}_PRIMARY naming.
-                                (when (seq pk)
-                                  (let [oid-row (table-oid pg-conn {:schema schema :table table})
-                                        oid     (:oid oid-row)]
-                                    (when oid
-                                      (swap! table-oids assoc (str schema "." table) oid)
-                                      (when-let [pk-sqls (ddl/create-primary-key-sql schema table pk oid)]
-                                        (run-ddl-tx pg-conn pk-sqls)))))
+                                  (when (seq pk)
+                                    (let [oid-row (table-oid pg-conn {:schema schema :table table})
+                                          oid     (:oid oid-row)]
+                                      (when oid
+                                        (swap! table-oids assoc (str schema "." table) oid)
+                                        (when-let [pk-sqls (ddl/create-primary-key-sql schema table pk oid)]
+                                          (run-ddl-tx pg-conn pk-sqls)))))
                   ;; Create ON UPDATE CURRENT_TIMESTAMP triggers
-                                (when-let [trg-sqls (ddl/create-triggers-sql schema table cols)]
-                                  (exec-post-ddl! pg-conn trg-sqls (str "TRIGGER on " table)))
-                                (stats/update-entry! :data table-label :rs-nanos (- (System/nanoTime) ddl-start)))
-                              (catch Exception e
-                                (log/error (str "Failed to create " schema "." table ": " (.getMessage e)))
-                                (stats/update-entry! :data table-label :errs 1)
-                                (swap! failed-tables conj table)))))
-                        (stats/update-entry! :pre "Create tables"
-                                             :rows (count cat)
-                                             :total-nanos (- (System/nanoTime) ddl-phase-start))))
+                                  (when-let [trg-sqls (ddl/create-triggers-sql schema table cols)]
+                                    (exec-post-ddl! pg-conn trg-sqls (str "TRIGGER on " table)))
+                                  (stats/update-entry! :data table-label :rs-nanos (- (System/nanoTime) ddl-start)))
+                                (catch Exception e
+                                  (log/error (str "Failed to create " schema "." table ": " (.getMessage e)))
+                                  (stats/update-entry! :data table-label :errs 1)
+                                  (reset! load-failed true)
+                                  (swap! failed-tables conj table)))))
+                          (stats/update-entry! :pre "Create tables"
+                                               :rows (count cat)
+                                               :total-nanos (- (System/nanoTime) ddl-phase-start))))
           ;; Create the index stats entry before Phase 2 so futures can update it.
-                    (when create-indexes?
-                      (stats/new-entry! :post "Create Indexes"))
+                      (when create-indexes?
+                        (stats/new-entry! :post "Create Indexes"))
           ;; Phase 2: COPY data only for tables whose DDL succeeded, using worker threads.
           ;; Each worker gets its own source connection and PostgreSQL connection so that
           ;; up to `workers` tables can be copied simultaneously (v3 workers= behavior).
-                    (when (not schema-only?)
+                      (when (not schema-only?)
           ;; Pre-create all per-table stats entries before spawning workers (prevents races).
-                      (doseq [t cat]
-                        (let [tl (table-stats-label (or (:schema t) "public") (:table-name t))]
-                          (when-not (some #(= (:label %) tl) (stats/entries :data))
-                            (stats/new-entry! :data tl))))
-                      (stats/new-entry! :post "COPY Wall-Clock Time")
-                      (let [copy-wall-t0    (System/nanoTime)
-                            mysql-set-params (when (#{:mysql :mariadb} (:type source-uri))
-                                               (seq (filter :is-mysql (:set-parameters cmd))))
-                            workers-pool    (Executors/newFixedThreadPool (int workers))
-                            table-futs
-                            (mapv
-                             (fn [[_i t]]
-                               (.submit ^ExecutorService workers-pool
-                                        ^java.util.concurrent.Callable
-                                        (fn []
-                                          (let [worker-src (source-from-uri source-uri table-spec
-                                                                            with-options source-overrides (:decoding-as cmd))
-                                                worker-pg  (postgres-connection target-uri)
-                                                pg-params  (seq (remove :is-mysql (:set-parameters cmd)))]
-                                            (when mysql-set-params
-                                              (mysql-source/execute-set-params! worker-src mysql-set-params))
-                                            (when pg-params
-                                              (doseq [param pg-params]
-                                                (try
-                                                  (jdbc/execute! worker-pg [(str "SET " (:var param) " TO '" (:value param) "'")])
-                                                  (.commit worker-pg)
-                                                  (catch Exception e
-                                                    (.rollback worker-pg)
-                                                    (log/warn (str "Worker SET failed: " (.getMessage e)))))))
-                                            (try
-                                              (let [schema      (or (:schema t) "public")
-                                                    table       (:table-name t)
-                                                    cols        (:columns t)
-                                                    table-label (table-stats-label schema table)]
-                                                (when-not (@failed-tables table)
-                                                  (let [;; Generated columns exist on the target (DDL emits
+                        (doseq [t cat]
+                          (let [tl (table-stats-label (or (:schema t) "public") (:table-name t))]
+                            (when-not (some #(= (:label %) tl) (stats/entries :data))
+                              (stats/new-entry! :data tl))))
+                        (stats/new-entry! :post "COPY Wall-Clock Time")
+                        (let [copy-wall-t0    (System/nanoTime)
+                              mysql-set-params (when (#{:mysql :mariadb} (:type source-uri))
+                                                 (seq (filter :is-mysql (:set-parameters cmd))))
+                              workers-pool    (Executors/newFixedThreadPool (int workers))
+                              table-futs
+                              (mapv
+                               (fn [[_i t]]
+                                 (.submit ^ExecutorService workers-pool
+                                          ^java.util.concurrent.Callable
+                                          (fn []
+                                            (let [worker-src (source-from-uri source-uri table-spec
+                                                                              with-options source-overrides (:decoding-as cmd))
+                                                  worker-pg  (postgres-connection target-uri)
+                                                  pg-params  (seq (remove :is-mysql (:set-parameters cmd)))]
+                                              (when mysql-set-params
+                                                (mysql-source/execute-set-params! worker-src mysql-set-params))
+                                              (when pg-params
+                                                (doseq [param pg-params]
+                                                  (try
+                                                    (jdbc/execute! worker-pg [(str "SET " (:var param) " TO '" (:value param) "'")])
+                                                    (.commit worker-pg)
+                                                    (catch Exception e
+                                                      (.rollback worker-pg)
+                                                      (log/warn (str "Worker SET failed: " (.getMessage e)))))))
+                                              (try
+                                                (let [schema      (or (:schema t) "public")
+                                                      table       (:table-name t)
+                                                      cols        (:columns t)
+                                                      table-label (table-stats-label schema table)]
+                                                  (when-not (@failed-tables table)
+                                                    (let [;; Generated columns exist on the target (DDL emits
                                       ;; GENERATED ALWAYS AS) but must be excluded from COPY
                                       ;; since PostgreSQL cannot accept values for them.
-                                                        copy-cols (remove :generated-expression cols)
-                                                        ts (cond-> {:schema schema :table-name table :columns copy-cols
-                                                                    :source-schema (:source-schema t)
-                                                                    :source-table-name (:source-table-name t)}
-                                                             (:citus-read-sql t) (assoc :citus-read-sql (:citus-read-sql t)))
-                                                        disable-triggers? (get with-options :disable-triggers false)]
-                                                    (when disable-triggers?
+                                                          copy-cols (remove :generated-expression cols)
+                                                          ts (cond-> {:schema schema :table-name table :columns copy-cols
+                                                                      :source-schema (:source-schema t)
+                                                                      :source-table-name (:source-table-name t)}
+                                                               (:citus-read-sql t) (assoc :citus-read-sql (:citus-read-sql t)))
+                                                          disable-triggers? (get with-options :disable-triggers false)]
+                                                      (when disable-triggers?
+                                                        (try
+                                                          (jdbc/execute! worker-pg ["SET session_replication_role = replica"])
+                                                          (.commit worker-pg)
+                                                          (catch Exception e
+                                                            (.rollback worker-pg)
+                                                            (log/warn (str "Failed to disable triggers: " (.getMessage e))))))
                                                       (try
-                                                        (jdbc/execute! worker-pg ["SET session_replication_role = replica"])
-                                                        (.commit worker-pg)
-                                                        (catch Exception e
-                                                          (.rollback worker-pg)
-                                                          (log/warn (str "Failed to disable triggers: " (.getMessage e))))))
-                                                    (try
-                                                      (let [parts (when (and multiple-readers? (> concurrency 1))
-                                                                    (seq (partition-source worker-src ts concurrency chunk-bytes)))
-                                                            result
-                                                            (if parts
-                                                              (do
-                                                                (log/info (str "COPY " table " using " (count parts) " parallel readers"))
-                                                                (let [part-exec (Executors/newVirtualThreadPerTaskExecutor)
-                                                                      part-futs
-                                                                      (mapv (fn [part-src]
-                                                                              (.submit ^ExecutorService part-exec
-                                                                                       ^java.util.concurrent.Callable
-                                                                                       (fn []
-                                                                                         (let [part-pg (postgres-connection target-uri)]
-                                                                                           (when pg-params
-                                                                                             (doseq [param pg-params]
-                                                                                               (try
-                                                                                                 (jdbc/execute! part-pg [(str "SET " (:var param) " TO '" (:value param) "'")])
-                                                                                                 (.commit part-pg)
-                                                                                                 (catch Exception _ (.rollback part-pg)))))
-                                                                                           (when disable-triggers?
-                                                                                             (try
-                                                                                               (jdbc/execute! part-pg ["SET session_replication_role = replica"])
-                                                                                               (.commit part-pg)
-                                                                                               (catch Exception _ (.rollback part-pg))))
-                                                                                           (try
-                                                                                             (copy-table part-src ts part-pg (:cast-rules cmd) (get with-options :projections []))
-                                                                                             (finally
-                                                                                               (close! part-src)
-                                                                                               (when disable-triggers?
+                                                        (let [parts (when (and multiple-readers? (> concurrency 1))
+                                                                      (seq (partition-source worker-src ts concurrency chunk-bytes)))
+                                                              result
+                                                              (if parts
+                                                                (do
+                                                                  (log/info (str "COPY " table " using " (count parts) " parallel readers"))
+                                                                  (let [part-exec (Executors/newVirtualThreadPerTaskExecutor)
+                                                                        part-futs
+                                                                        (mapv (fn [part-src]
+                                                                                (.submit ^ExecutorService part-exec
+                                                                                         ^java.util.concurrent.Callable
+                                                                                         (fn []
+                                                                                           (let [part-pg (postgres-connection target-uri)]
+                                                                                             (when pg-params
+                                                                                               (doseq [param pg-params]
                                                                                                  (try
-                                                                                                   (jdbc/execute! part-pg ["SET session_replication_role = origin"])
+                                                                                                   (jdbc/execute! part-pg [(str "SET " (:var param) " TO '" (:value param) "'")])
                                                                                                    (.commit part-pg)
-                                                                                                   (catch Exception _ (.rollback part-pg))))
-                                                                                               (.close ^java.sql.Connection part-pg)))))))
-                                                                            parts)]
-                                                                  (try
-                                                                    (reduce
-                                                                     (fn [acc ^java.util.concurrent.Future f]
-                                                                       (let [r (.get f)]
-                                                                         {:rows-ok     (+ (:rows-ok acc) (:rows-ok r))
-                                                                          :rows-bad    (+ (:rows-bad acc) (:rows-bad r))
-                                                                          :bytes       (+ (:bytes acc) (:bytes r))
-                                                                          :rs-nanos    (max (:rs-nanos acc) (:rs-nanos r))
-                                                                          :ws-nanos    (max (:ws-nanos acc) (:ws-nanos r))
-                                                                          :total-nanos (max (:total-nanos acc) (:total-nanos r))
-                                                                          :reject-paths (:reject-paths r)}))
-                                                                     {:rows-ok 0 :rows-bad 0 :bytes 0 :rs-nanos 0 :ws-nanos 0 :total-nanos 0 :reject-paths nil}
-                                                                     part-futs)
-                                                                    (finally
-                                                                      (.shutdown ^ExecutorService part-exec)
-                                                                      (.awaitTermination ^ExecutorService part-exec Long/MAX_VALUE TimeUnit/NANOSECONDS)))))
-                                                              (copy-table worker-src ts worker-pg (:cast-rules cmd) (get with-options :projections [])))]
-                                                        (log/info (str "COPY " table " done: "
-                                                                       (:rows-ok result) " rows in "
-                                                                       (plog/fmt-duration (:total-nanos result))))
-                                                        (when (pos? (:rows-bad result))
-                                                          (log/warn (str table ": " (:rows-bad result) " rows rejected"
-                                                                         (when-let [p (-> result :reject-paths :reject-log)]
-                                                                           (str ", see " p)))))
-                                                        (let [reject-paths (:reject-paths result)]
-                                                          (stats/update-entry! :data table-label
-                                                                               :read (:rows-ok result)
-                                                                               :rows (:rows-ok result)
-                                                                               :errs (:rows-bad result)
-                                                                               :bytes (:bytes result)
-                                                                               :rs-nanos (:rs-nanos result)
-                                                                               :ws-nanos (:ws-nanos result)
-                                                                               :total-nanos (:total-nanos result)
-                                                                               :reject-data (:reject-data reject-paths)
-                                                                               :reject-log (:reject-log reject-paths))))
-                                                      (catch Exception e
-                                                        (log/error e (str "Failed to copy table " schema "." table ": " (.getMessage e)))
-                                                        (stats/update-entry! :data table-label :errs 1)
-                                                        (when copy/*on-error-stop*
-                                                          (log/error "ON ERROR STOP — aborting remaining tables")
-                                                          (throw e)))
-                                                      (finally
+                                                                                                   (catch Exception _ (.rollback part-pg)))))
+                                                                                             (when disable-triggers?
+                                                                                               (try
+                                                                                                 (jdbc/execute! part-pg ["SET session_replication_role = replica"])
+                                                                                                 (.commit part-pg)
+                                                                                                 (catch Exception _ (.rollback part-pg))))
+                                                                                             (try
+                                                                                               (copy-table part-src ts part-pg (:cast-rules cmd) (get with-options :projections []))
+                                                                                               (finally
+                                                                                                 (close! part-src)
+                                                                                                 (when disable-triggers?
+                                                                                                   (try
+                                                                                                     (jdbc/execute! part-pg ["SET session_replication_role = origin"])
+                                                                                                     (.commit part-pg)
+                                                                                                     (catch Exception _ (.rollback part-pg))))
+                                                                                                 (.close ^java.sql.Connection part-pg)))))))
+                                                                              parts)]
+                                                                    (try
+                                                                      (reduce
+                                                                       (fn [acc ^java.util.concurrent.Future f]
+                                                                         (let [r (.get f)]
+                                                                           {:rows-ok     (+ (:rows-ok acc) (:rows-ok r))
+                                                                            :rows-bad    (+ (:rows-bad acc) (:rows-bad r))
+                                                                            :bytes       (+ (:bytes acc) (:bytes r))
+                                                                            :rs-nanos    (max (:rs-nanos acc) (:rs-nanos r))
+                                                                            :ws-nanos    (max (:ws-nanos acc) (:ws-nanos r))
+                                                                            :total-nanos (max (:total-nanos acc) (:total-nanos r))
+                                                                            :reject-paths (:reject-paths r)}))
+                                                                       {:rows-ok 0 :rows-bad 0 :bytes 0 :rs-nanos 0 :ws-nanos 0 :total-nanos 0 :reject-paths nil}
+                                                                       part-futs)
+                                                                      (finally
+                                                                        (.shutdown ^ExecutorService part-exec)
+                                                                        (.awaitTermination ^ExecutorService part-exec Long/MAX_VALUE TimeUnit/NANOSECONDS)))))
+                                                                (copy-table worker-src ts worker-pg (:cast-rules cmd) (get with-options :projections [])))]
+                                                          (log/info (str "COPY " table " done: "
+                                                                         (:rows-ok result) " rows in "
+                                                                         (plog/fmt-duration (:total-nanos result))))
+                                                          (when (pos? (:rows-bad result))
+                                                            (log/warn (str table ": " (:rows-bad result) " rows rejected"
+                                                                           (when-let [p (-> result :reject-paths :reject-log)]
+                                                                             (str ", see " p)))))
+                                                          (let [reject-paths (:reject-paths result)]
+                                                            (stats/update-entry! :data table-label
+                                                                                 :read (:rows-ok result)
+                                                                                 :rows (:rows-ok result)
+                                                                                 :errs (:rows-bad result)
+                                                                                 :bytes (:bytes result)
+                                                                                 :rs-nanos (:rs-nanos result)
+                                                                                 :ws-nanos (:ws-nanos result)
+                                                                                 :total-nanos (:total-nanos result)
+                                                                                 :reject-data (:reject-data reject-paths)
+                                                                                 :reject-log (:reject-log reject-paths))))
+                                                        (catch Exception e
+                                                          (log/error e (str "Failed to copy table " schema "." table ": " (.getMessage e)))
+                                                          (stats/update-entry! :data table-label :errs 1)
+                                                          (reset! load-failed true)
+                                                          (when copy/*on-error-stop*
+                                                            (log/error "ON ERROR STOP — aborting remaining tables")
+                                                            (throw e)))
+                                                        (finally
                                       ;; Reset triggers on worker-pg when single-reader path used it
-                                                        (when disable-triggers?
-                                                          (try
-                                                            (jdbc/execute! worker-pg ["SET session_replication_role = origin"])
-                                                            (.commit worker-pg)
-                                                            (catch Exception e2
-                                                              (.rollback worker-pg)
-                                                              (log/warn (str "Failed to re-enable triggers: " (.getMessage e2))))))))
+                                                          (when disable-triggers?
+                                                            (try
+                                                              (jdbc/execute! worker-pg ["SET session_replication_role = origin"])
+                                                              (.commit worker-pg)
+                                                              (catch Exception e2
+                                                                (.rollback worker-pg)
+                                                                (log/warn (str "Failed to re-enable triggers: " (.getMessage e2))))))))
                                   ;; Submit indexes after all readers for this table are done.
-                                                    (when (and idx-executor (seq (:indexes t)))
-                                                      (when (nil? @idx-wall-t0)
-                                                        (reset! idx-wall-t0 (System/nanoTime)))
-                                                      (let [oid  (when-not preserve-index-names?
-                                                                   (get @table-oids (str schema "." table)))
-                                                            sqls (ddl/create-indexes-sql schema table (:indexes t) oid)]
-                                                        (doseq [sql sqls]
-                                                          (swap! idx-futures conj
-                                                                 (.submit ^ExecutorService idx-executor
-                                                                          ^java.util.concurrent.Callable
-                                                                          (fn []
-                                                                            (let [conn (postgres-connection target-uri)]
-                                                                              (try
-                                                                                (exec-post-ddl! conn [sql] (str "INDEX on " table))
-                                                                                (finally (.close ^Connection conn)))))))))))))
-                                              (finally
-                                                (close! worker-src)
-                                                (.close ^Connection worker-pg)))))))
-                             (map-indexed vector cat))]
-                        (.shutdown ^ExecutorService workers-pool)
-                        (.awaitTermination ^ExecutorService workers-pool Long/MAX_VALUE TimeUnit/NANOSECONDS)
-                        (doseq [^Future f table-futs]
-                          (try (.get f) (catch Exception _)))
-                        (stats/update-entry! :post "COPY Wall-Clock Time"
-                                             :total-nanos (- (System/nanoTime) copy-wall-t0))))
+                                                      (when (and idx-executor (seq (:indexes t)))
+                                                        (when (nil? @idx-wall-t0)
+                                                          (reset! idx-wall-t0 (System/nanoTime)))
+                                                        (let [oid  (when-not preserve-index-names?
+                                                                     (get @table-oids (str schema "." table)))
+                                                              sqls (ddl/create-indexes-sql schema table (:indexes t) oid)]
+                                                          (doseq [sql sqls]
+                                                            (swap! idx-futures conj
+                                                                   (.submit ^ExecutorService idx-executor
+                                                                            ^java.util.concurrent.Callable
+                                                                            (fn []
+                                                                              (let [conn (postgres-connection target-uri)]
+                                                                                (try
+                                                                                  (exec-post-ddl! conn [sql] (str "INDEX on " table))
+                                                                                  (finally (.close ^Connection conn)))))))))))))
+                                                (finally
+                                                  (close! worker-src)
+                                                  (.close ^Connection worker-pg)))))))
+                               (map-indexed vector cat))]
+                          (.shutdown ^ExecutorService workers-pool)
+                          (.awaitTermination ^ExecutorService workers-pool Long/MAX_VALUE TimeUnit/NANOSECONDS)
+                          (doseq [^Future f table-futs]
+                            (try (.get f) (catch Exception _)))
+                          (stats/update-entry! :post "COPY Wall-Clock Time"
+                                               :total-nanos (- (System/nanoTime) copy-wall-t0))))
           ;; Schema-only: no COPY phase ran, so submit all indexes now.
-                    (when (and create-indexes? schema-only? idx-executor)
-                      (when (nil? @idx-wall-t0)
-                        (reset! idx-wall-t0 (System/nanoTime)))
-                      (doseq [t cat]
-                        (let [schema (or (:schema t) "public")
-                              table  (:table-name t)]
-                          (when-let [idxs (seq (:indexes t))]
-                            (let [oid  (when-not preserve-index-names?
-                                         (get @table-oids (str schema "." table)))
-                                  sqls (ddl/create-indexes-sql schema table idxs oid)]
-                              (doseq [sql sqls]
-                                (swap! idx-futures conj
-                                       (.submit ^ExecutorService idx-executor
-                                                ^java.util.concurrent.Callable
-                                                (fn []
-                                                  (let [conn (postgres-connection target-uri)]
-                                                    (try
-                                                      (exec-post-ddl! conn [sql] (str "INDEX on " table))
-                                                      (finally (.close ^Connection conn)))))))))))))
+                      (when (and create-indexes? schema-only? idx-executor)
+                        (when (nil? @idx-wall-t0)
+                          (reset! idx-wall-t0 (System/nanoTime)))
+                        (doseq [t cat]
+                          (let [schema (or (:schema t) "public")
+                                table  (:table-name t)]
+                            (when-let [idxs (seq (:indexes t))]
+                              (let [oid  (when-not preserve-index-names?
+                                           (get @table-oids (str schema "." table)))
+                                    sqls (ddl/create-indexes-sql schema table idxs oid)]
+                                (doseq [sql sqls]
+                                  (swap! idx-futures conj
+                                         (.submit ^ExecutorService idx-executor
+                                                  ^java.util.concurrent.Callable
+                                                  (fn []
+                                                    (let [conn (postgres-connection target-uri)]
+                                                      (try
+                                                        (exec-post-ddl! conn [sql] (str "INDEX on " table))
+                                                        (finally (.close ^Connection conn)))))))))))))
           ;; Await completion of all parallel index builds (overlapped with copy above).
-                    (when create-indexes?
-                      (when idx-executor
-                        (log/info "Waiting for parallel index builds to complete")
-                        (.shutdown ^ExecutorService idx-executor)
-                        (.awaitTermination ^ExecutorService idx-executor Long/MAX_VALUE TimeUnit/NANOSECONDS)
-                        (doseq [^Future f @idx-futures]
-                          (try (.get f) (catch Exception _))))
-                      (stats/update-entry! :post "Create Indexes"
-                                           :rows (count @idx-futures)
-                                           :total-nanos (- (System/nanoTime) (or @idx-wall-t0 (System/nanoTime)))))
-                    (when (get with-options :foreign-keys false)
-                      (log/info "Creating foreign keys")
-                      (stats/new-entry! :post "Create Foreign Keys")
-                      (let [start (System/nanoTime)
-                            n     (atom 0)]
-                        (doseq [t cat]
-                          (let [schema (or (:schema t) "public")
-                                table  (:table-name t)]
-                            (when-let [fks (seq (:fkeys t))]
-                              (exec-post-ddl! pg-conn
-                                              (ddl/create-fkeys-sql schema table fks)
-                                              (str "FK on " table))
-                              (swap! n + (count fks)))))
-                        (stats/update-entry! :post "Create Foreign Keys"
-                                             :rows @n :total-nanos (- (System/nanoTime) start))))
-                    (when (get with-options :reset-sequences false)
-                      (log/info "Resetting sequences")
-                      (stats/new-entry! :post "Reset Sequences")
-                      (let [start (System/nanoTime)
-                            n     (atom 0)]
-                        (doseq [t cat]
-                          (let [schema (or (:schema t) "public")
-                                table  (:table-name t)]
-                            (when-let [seqs (seq (ddl/reset-sequences-sql schema table (:columns t)))]
-                              (exec-post-ddl! pg-conn seqs (str "SEQUENCE for " table))
-                              (swap! n inc))))
-                        (stats/update-entry! :post "Reset Sequences"
-                                             :rows @n :total-nanos (- (System/nanoTime) start)))))
-        ;; Execute AFTER LOAD DO statements — all in one transaction
-                  (when-let [after-cmds (:after-load cmd)]
-                    (log/debug "Executing AFTER LOAD DO commands")
-                    (try
-                      (doseq [sql after-cmds]
-                        (log/debug (str "AFTER LOAD: " (clojure.string/trim sql)))
-                        (jdbc/execute! pg-conn [sql]))
-                      (.commit pg-conn)
-                      (catch Exception e
-                        (.rollback pg-conn)
-                        (log/error e "AFTER LOAD DO failed"))))
+                      (when create-indexes?
+                        (when idx-executor
+                          (log/info "Waiting for parallel index builds to complete")
+                          (.shutdown ^ExecutorService idx-executor)
+                          (.awaitTermination ^ExecutorService idx-executor Long/MAX_VALUE TimeUnit/NANOSECONDS)
+                          (doseq [^Future f @idx-futures]
+                            (try (.get f) (catch Exception _))))
+                        (stats/update-entry! :post "Create Indexes"
+                                             :rows (count @idx-futures)
+                                             :total-nanos (- (System/nanoTime) (or @idx-wall-t0 (System/nanoTime)))))
+                      (when (get with-options :foreign-keys false)
+                        (log/info "Creating foreign keys")
+                        (stats/new-entry! :post "Create Foreign Keys")
+                        (let [start          (System/nanoTime)
+                              n              (atom 0)
+                            ;; ORM mode: only include FKs whose referenced table was
+                            ;; actually loaded (avoids silent failure when tables are
+                            ;; excluded via INCLUDING/EXCLUDING filters, #1216).
+                              loaded-tables  (into #{} (map :table-name cat))]
+                          (doseq [t cat]
+                            (let [schema (or (:schema t) "public")
+                                  table  (:table-name t)
+                                  fks    (filter #(loaded-tables (:ftable %)) (:fkeys t))]
+                              (when (seq fks)
+                                (exec-post-ddl! pg-conn
+                                                (ddl/create-fkeys-sql schema table fks)
+                                                (str "FK on " table))
+                                (swap! n + (count fks)))))
+                          (stats/update-entry! :post "Create Foreign Keys"
+                                               :rows @n :total-nanos (- (System/nanoTime) start))))
+                      (when (get with-options :reset-sequences false)
+                        (log/info "Resetting sequences")
+                        (stats/new-entry! :post "Reset Sequences")
+                        (let [start (System/nanoTime)
+                              n     (atom 0)]
+                          (doseq [t cat]
+                            (let [schema (or (:schema t) "public")
+                                  table  (:table-name t)]
+                              (when-let [seqs (seq (ddl/reset-sequences-sql schema table (:columns t)))]
+                                (exec-post-ddl! pg-conn seqs (str "SEQUENCE for " table))
+                                (swap! n inc))))
+                          (stats/update-entry! :post "Reset Sequences"
+                                               :rows @n :total-nanos (- (System/nanoTime) start)))))
+        ;; Execute AFTER LOAD DO statements — skip when the load failed (#930).
+                    (when-let [after-cmds (and (not @load-failed) (seq (:after-load cmd)))]
+                      (log/debug "Executing AFTER LOAD DO commands")
+                      (try
+                        (doseq [sql after-cmds]
+                          (log/debug (str "AFTER LOAD: " (clojure.string/trim sql)))
+                          (jdbc/execute! pg-conn [sql]))
+                        (.commit pg-conn)
+                        (catch Exception e
+                          (.rollback pg-conn)
+                          (log/error e "AFTER LOAD DO failed"))))
         ;; ── Citus distribution ────────────────────────────────────────────
-                  (when-let [rules (seq (citus/expand-distribute-rules cat (:distribute-rules cmd)))]
-                    (log/info (str "Applying " (count rules) " Citus distribution rule(s)"))
-                    (let [schema-by-table (into {} (map (juxt :table-name :schema) cat))]
-                      (doseq [rule rules]
-                        (let [tgt-schema (or (get schema-by-table (:table rule))
-                                             (get-in cmd [:target :schema])
-                                             "public")]
-                          (try
-                            (citus/execute-distribute! pg-conn (assoc rule :schema tgt-schema))
-                            (.commit pg-conn)
-                            (log/info (str "  " (:table rule)
-                                           (if (= :reference (:type rule))
-                                             " → reference table"
-                                             (str " → distributed on " (:using rule)))))
-                            (catch Exception e
-                              (log/error e (str "Failed to distribute " (:table rule)
-                                                ": " (.getMessage e)))
-                              (.rollback pg-conn)))))))
-                  (log/info "Done copying all tables")))
+                    (when-let [rules (seq (citus/expand-distribute-rules cat (:distribute-rules cmd)))]
+                      (log/info (str "Applying " (count rules) " Citus distribution rule(s)"))
+                      (let [schema-by-table (into {} (map (juxt :table-name :schema) cat))]
+                        (doseq [rule rules]
+                          (let [tgt-schema (or (get schema-by-table (:table rule))
+                                               (get-in cmd [:target :schema])
+                                               "public")]
+                            (try
+                              (citus/execute-distribute! pg-conn (assoc rule :schema tgt-schema))
+                              (.commit pg-conn)
+                              (log/info (str "  " (:table rule)
+                                             (if (= :reference (:type rule))
+                                               " → reference table"
+                                               (str " → distributed on " (:using rule)))))
+                              (catch Exception e
+                                (log/error e (str "Failed to distribute " (:table rule)
+                                                  ": " (.getMessage e)))
+                                (.rollback pg-conn)))))))
+                    (log/info "Done copying all tables"))))
 
               (finally
                 (close! source)

--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -1,7 +1,8 @@
 (ns pgloader.ddl.common
   (:require [hugsql.core :as hugsql]
             [pgloader.cast :as cast]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]))
 
 (set! *warn-on-reflection* true)
 
@@ -307,22 +308,51 @@
                  on-upd on-del ";\n")))
         fkeys))
 
+(def ^:private pg-max-identifier-length 63)
+
+(defn- snake-case-transform
+  "Convert an identifier to snake_case:
+   1. Insert underscore between camelCase boundaries (Foo → foo, FooBar → foo_bar).
+   2. Replace spaces and hyphens with underscore.
+   3. Collapse consecutive underscores (Object_Name → object_name, not object__name).
+   4. Replace $ with _ ($ is valid in MySQL/SQLite but not meaningful in PG identifiers).
+   5. Lowercase the whole result.
+   6. Truncate to 63 bytes (PostgreSQL max identifier length) with a warning when trimmed."
+  [^String s]
+  (let [result (-> s
+                   ;; camelCase → snake_case: insert _ between lower→upper transitions
+                   (str/replace #"([a-z\d])([A-Z])" "$1_$2")
+                   ;; Handle runs of uppercase followed by lowercase: XMLParser → xml_parser
+                   (str/replace #"([A-Z]+)([A-Z][a-z])" "$1_$2")
+                   ;; Replace spaces, hyphens, $ with underscore
+                   (str/replace #"[\s\-$]+" "_")
+                   str/lower-case
+                   ;; Collapse consecutive underscores (e.g. Object_Name → object_name)
+                   (str/replace #"_+" "_")
+                   ;; Strip leading/trailing underscores that may have appeared
+                   (str/replace #"^_+|_+$" ""))]
+    (if (> (count result) pg-max-identifier-length)
+      (do (log/warn (str "Identifier truncated to " pg-max-identifier-length
+                         " characters: " result))
+          (subs result 0 pg-max-identifier-length))
+      result)))
+
 (defn apply-identifier-case
   "Transform identifiers in the catalog according to with-options.
    Matches CL pgloader behaviour:
    - Default (no option): preserve original case (quote identifiers).
    - :quote-ids           preserve original case (same as default).
    - :downcase-ids        explicit lowercase.
-   - :snake-case-ids      lowercase + replace hyphens/spaces with underscores."
+   - :snake-case-ids      camelCase → snake_case + lowercase."
   [catalog with-options]
   (let [downcase? (get with-options :downcase-ids false)
-        snake? (get with-options :snake-case-ids false)]
+        snake?    (get with-options :snake-case-ids false)]
     (if (not (or downcase? snake?))
       catalog
       (mapv (fn [t]
-              (let [xf (fn [s]
-                         (cond-> (str/lower-case s)
-                           snake? (str/replace #"-" "_")))]
+              (let [xf (if snake?
+                         snake-case-transform
+                         str/lower-case)]
                 (-> t
                     (update :table-name xf)
                     (update :schema     xf)
@@ -333,7 +363,11 @@
                             (fn [pk] (mapv xf pk)))
                     (update :indexes
                             (fn [idxes]
-                              (mapv #(update % :columns (fn [cs] (mapv xf cs))) idxes)))
+                              (mapv (fn [idx]
+                                      (-> idx
+                                          (update :name xf)
+                                          (update :columns (fn [cs] (mapv xf cs)))))
+                                    idxes)))
                     (update :fkeys
                             (fn [fks]
                               (mapv (fn [fk]

--- a/clojure/src/pgloader/stats.clj
+++ b/clojure/src/pgloader/stats.clj
@@ -27,8 +27,21 @@
    :data (make-phase)
    :post (make-phase)})
 
+(def ^:private fatal-error (atom false))
+
+(defn fatal-error!
+  "Signal that a fatal (non-row-level) load error occurred."
+  []
+  (reset! fatal-error true))
+
+(defn fatal-error?
+  "Return true if a fatal load error was signalled."
+  []
+  @fatal-error)
+
 (defn clear!
   []
+  (reset! fatal-error false)
   (doseq [p (vals state)]
     (reset! (:entries p) [])))
 

--- a/clojure/test/pgloader/ddl_test.clj
+++ b/clojure/test/pgloader/ddl_test.clj
@@ -148,3 +148,105 @@
       (is (= "\"first_name\" || ' ' || \"last_name\"" result))))
   (testing "mysql-gen-expr->pg returns nil for blank expression"
     (is (nil? (#'pgloader.source.mysql/mysql-gen-expr->pg "")))))
+
+;; ── snake_case identifier transformation (#1286, #1287, #1320, #1327, #1344) ──
+
+(defn- make-table [table-name col-names idx-names]
+  {:table-name  table-name
+   :schema      "public"
+   :columns     (mapv #(hash-map :column-name %) col-names)
+   :primary-key []
+   :indexes     (mapv #(hash-map :name % :columns [%] :unique false) idx-names)
+   :fkeys       []})
+
+(deftest test-snake-case-transform
+  (testing "basic camelCase to snake_case"
+    (let [[t] (ddl/apply-identifier-case [(make-table "FooBar" ["fooBar" "BazQux"] [])]
+                                         {:snake-case-ids true})]
+      (is (= "foo_bar" (:table-name t)))
+      (is (= ["foo_bar" "baz_qux"] (mapv :column-name (:columns t))))))
+
+  (testing "existing underscores not doubled (#1287)"
+    (let [[t] (ddl/apply-identifier-case [(make-table "Object_Name" ["Object_Name"] [])]
+                                         {:snake-case-ids true})]
+      (is (= "object_name" (:table-name t)))
+      (is (= ["object_name"] (mapv :column-name (:columns t))))))
+
+  (testing "SQL keywords are still downcased (#1320)"
+    (let [[t] (ddl/apply-identifier-case [(make-table "Order" ["User" "From" "To"] [])]
+                                         {:snake-case-ids true})]
+      (is (= "order" (:table-name t)))
+      (is (= ["user" "from" "to"] (mapv :column-name (:columns t))))))
+
+  (testing "dollar sign replaced by underscore (#1344)"
+    (let [[t] (ddl/apply-identifier-case [(make-table "table$name" ["col$one"] [])]
+                                         {:snake-case-ids true})]
+      (is (= "table_name" (:table-name t)))
+      (is (= ["col_one"] (mapv :column-name (:columns t))))))
+
+  (testing "index names also transformed (#1327)"
+    (let [[t] (ddl/apply-identifier-case [(make-table "t" [] ["MyIndex" "Object_IDX"])]
+                                         {:snake-case-ids true})]
+      (is (= ["my_index" "object_idx"] (mapv :name (:indexes t))))))
+
+  (testing "table name truncated at 63 chars (#1286)"
+    (let [long-name (apply str (repeat 70 "a"))
+          [t] (ddl/apply-identifier-case [(make-table long-name [] [])]
+                                         {:snake-case-ids true})]
+      (is (= 63 (count (:table-name t))))))
+
+  (testing "downcase-ids still works for plain lowercase"
+    (let [[t] (ddl/apply-identifier-case [(make-table "MyTable" ["MyCol"] [])]
+                                         {:downcase-ids true})]
+      (is (= "mytable" (:table-name t)))
+      (is (= ["mycol"] (mapv :column-name (:columns t))))))
+
+  (testing "XMLParser-style all-caps prefix handled"
+    (let [[t] (ddl/apply-identifier-case [(make-table "XMLParser" [] [])]
+                                         {:snake-case-ids true})]
+      (is (= "xml_parser" (:table-name t))))))
+
+;; ── FK filter (#1216) ─────────────────────────────────────────────────────────
+
+(deftest test-create-fkeys-sql-filters-missing-tables
+  (testing "create-fkeys-sql generates SQL for all provided fkeys"
+    (let [fkeys [{:name "fk_orders_user" :columns ["user_id"] :ftable "users"
+                  :fcols ["id"] :on-delete nil :on-update nil}
+                 {:name "fk_orders_product" :columns ["product_id"] :ftable "products"
+                  :fcols ["id"] :on-delete "CASCADE" :on-update nil}]
+          sql (ddl/create-fkeys-sql "public" "orders" fkeys)]
+      (is (= 2 (count sql)))
+      (is (str/includes? (first sql) "REFERENCES \"public\".\"users\""))
+      (is (str/includes? (second sql) "ON DELETE CASCADE"))))
+
+  (testing "filtering fkeys to loaded tables excludes unloaded referenced tables (#1216)"
+    (let [all-fkeys [{:name "fk_a" :columns ["x"] :ftable "loaded_table"
+                      :fcols ["id"] :on-delete nil :on-update nil}
+                     {:name "fk_b" :columns ["y"] :ftable "excluded_table"
+                      :fcols ["id"] :on-delete nil :on-update nil}]
+          loaded-tables #{"loaded_table"}
+          fkeys (filter #(loaded-tables (:ftable %)) all-fkeys)
+          sql (ddl/create-fkeys-sql "public" "source_table" fkeys)]
+      (is (= 1 (count sql)))
+      (is (str/includes? (first sql) "REFERENCES \"public\".\"loaded_table\"")))))
+
+;; ── enum-types with include-no-drop (#1001) ───────────────────────────────────
+
+(deftest test-create-enum-types-sql
+  (testing "create-enum-types-sql generates DROP + CREATE pairs"
+    (let [sqls (ddl/create-enum-types-sql [{:type-name "color_enum"
+                                            :schema    "public"
+                                            :values    ["red" "green" "blue"]
+                                            :is-set    false}])]
+      (is (= 2 (count sqls)))
+      (is (str/starts-with? (first sqls) "DROP TYPE IF EXISTS"))
+      (is (str/starts-with? (second sqls) "CREATE TYPE"))))
+
+  (testing "filtering out DROP statements honours include-no-drop"
+    (let [sqls    (ddl/create-enum-types-sql [{:type-name "status_enum"
+                                               :schema    "public"
+                                               :values    ["active" "inactive"]
+                                               :is-set    false}])
+          no-drop (remove #(str/starts-with? % "DROP") sqls)]
+      (is (= 1 (count no-drop)))
+      (is (str/starts-with? (first no-drop) "CREATE TYPE")))))


### PR DESCRIPTION
## Summary

Two batches of fixes for the Clojure v4 rewrite.

### PR-5 — snake_case identifier fixes

- **#1287** Prevent consecutive underscores when source identifier already contains underscores (e.g. `Object_Name` → `object_name`, not `object__name`)
- **#1320** SQL keyword identifiers are still downcased correctly in snake mode (e.g. `Order` → `order`)
- **#1286** Identifiers longer than 63 characters are truncated with a warning log
- **#1327** Index names are also passed through `apply-identifier-case`, not just table/column names
- **#1344** Dollar signs (`$`) in identifiers are replaced by underscores

### PR-6 — core behaviour fixes

- **#634** CLI exits with code 1 when `stats/grand-totals` reports any errors after all commands
- **#930** AFTER LOAD SQL is gated on load success — skipped when the data load itself failed
- **#1001** `DROP TYPE` statements are skipped when `WITH include no drop` is set for ENUM types
- **#1216** FK creation in ORM mode filters out foreign keys whose referenced table was not actually loaded

## Tests

127 tests, 420 assertions, 0 failures, 0 errors.  
New unit tests added for all 9 fixes in `ddl_test.clj`.

Closes #634
Closes #930
Closes #1001
Closes #1216
Closes #1286
Closes #1287
Closes #1320
Closes #1327
Closes #1344