### PR TITLE
MySQL type system, enum/cast/type edge cases (17 issues)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ web/howto/sqlite.html
 system-index.txt
 buildapp.log
 docs/_build
+.claude/worktrees/

--- a/clojure/src/pgloader/cast.clj
+++ b/clojure/src/pgloader/cast.clj
@@ -333,8 +333,8 @@
    changes :column-type to the PostgreSQL target.
    Also stores :cast-fn so the DDL layer can apply the same transform to
    default values (mirrors CL format-default-value).
-   Rules with :without-type true (from 'without type' syntax, #1522) match
-   the column but do not change its type."
+   Rules with no :target-type (column cast without a 'to TYPE' clause) match
+   the column and apply the cast function without changing its type."
   [columns cast-rules]
   (mapv (fn [col]
           (if-let [rule (some #(when (matches-rule? % col) %) cast-rules)]
@@ -347,12 +347,12 @@
                 cast-kw
                 (assoc :cast-fn cast-kw)
 
-                ;; without-type: keep existing type; only apply cast-fn (#1522)
-                (and (:target-type rule) (not (:without-type rule)))
+                ;; only override the column type when the rule specifies one
+                (:target-type rule)
                 (assoc :column-type (:target-type rule))
 
                 (and (get-in rule [:options :drop-typemod])
-                     (not (:without-type rule)))
+                     (:target-type rule))
                 (assoc :column-type
                        (-> (:target-type rule)
                            (or (:column-type col))

--- a/clojure/src/pgloader/cast.clj
+++ b/clojure/src/pgloader/cast.clj
@@ -136,6 +136,19 @@
                 (.longValue p4) (.longValue p5)))
       (catch Exception _ v))))
 
+(defn hex-to-bytea
+  "Convert a hex string to PostgreSQL bytea \\x... format (#1066).
+   Input may be plain hex (DEADBEEF) or prefixed (0xDEADBEEF / \\xDEADBEEF).
+   Used when loading CSV/fixed fields that carry hex-encoded binary data."
+  [^String v]
+  (when v
+    (let [trimmed (str/trim v)
+          hex (cond
+                (str/starts-with? trimmed "0x") (subs trimmed 2)
+                (str/starts-with? trimmed "\\x") (subs trimmed 2)
+                :else trimmed)]
+      (str "\\x" (str/lower-case hex)))))
+
 (defn set-to-enum-array
   "Convert a MySQL SET value (comma-separated string) to PostgreSQL array format {val1,val2}.
    Mirrors CL pgloader's set-to-enum-array."
@@ -205,6 +218,7 @@
    :set-to-enum-array            set-to-enum-array
    :convert-mysql-point          convert-mysql-point
    :convert-mysql-linestring     convert-mysql-linestring
+   :hex-to-bytea                 hex-to-bytea
    :none                         identity})
 
 ;; ── Rule matching ─────────────────────────────────────────────────
@@ -318,7 +332,9 @@
    resolve-specs can still match on the original type after DDL generation
    changes :column-type to the PostgreSQL target.
    Also stores :cast-fn so the DDL layer can apply the same transform to
-   default values (mirrors CL format-default-value)."
+   default values (mirrors CL format-default-value).
+   Rules with :without-type true (from 'without type' syntax, #1522) match
+   the column but do not change its type."
   [columns cast-rules]
   (mapv (fn [col]
           (if-let [rule (some #(when (matches-rule? % col) %) cast-rules)]
@@ -331,10 +347,12 @@
                 cast-kw
                 (assoc :cast-fn cast-kw)
 
-                (:target-type rule)
+                ;; without-type: keep existing type; only apply cast-fn (#1522)
+                (and (:target-type rule) (not (:without-type rule)))
                 (assoc :column-type (:target-type rule))
 
-                (get-in rule [:options :drop-typemod])
+                (and (get-in rule [:options :drop-typemod])
+                     (not (:without-type rule)))
                 (assoc :column-type
                        (-> (:target-type rule)
                            (or (:column-type col))

--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -836,6 +836,20 @@
                                 (swap! n + (count fks)))))
                           (stats/update-entry! :post "Create Foreign Keys"
                                                :rows @n :total-nanos (- (System/nanoTime) start))))
+                      (let [all-checks (mapcat (fn [t]
+                                                 (ddl/create-check-constraints-sql
+                                                  (or (:schema t) "public")
+                                                  (:table-name t)
+                                                  (:checks t)))
+                                               cat)]
+                        (when (seq all-checks)
+                          (log/info "Creating CHECK constraints")
+                          (stats/new-entry! :post "Create Check Constraints")
+                          (let [start (System/nanoTime)]
+                            (exec-post-ddl! pg-conn all-checks "CHECK constraints")
+                            (stats/update-entry! :post "Create Check Constraints"
+                                                 :rows (count all-checks)
+                                                 :total-nanos (- (System/nanoTime) start)))))
                       (when (get with-options :reset-sequences false)
                         (log/info "Resetting sequences")
                         (stats/new-entry! :post "Reset Sequences")

--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -18,15 +18,20 @@
    (str (identifier-quote schema) "." (identifier-quote table))))
 
 (defn- pg-type-for
-  "Map a MySQL type name to PostgreSQL type."
+  "Map a MySQL type name to PostgreSQL type.
+   Preserves precision modifiers for temporal types (#1629)."
   [^String mysql-type ^String extra]
   (let [upper (str/upper-case mysql-type)
         lower (str/lower-case mysql-type)
-        unsigned? (str/includes? lower "unsigned")]
+        unsigned? (str/includes? lower "unsigned")
+        ;; Extract precision modifier like (6) from datetime(6)
+        typemod (re-find #"\(\d+\)" mysql-type)]
     (cond
       ;; Pass-through: native PostgreSQL types emitted by non-MySQL sources
       (= lower "uuid")   "uuid"
       (= lower "xml")    "xml"
+      ;; Pass-through array types from PostgreSQL sources (#1371)
+      (str/ends-with? lower "[]") lower
       (str/starts-with? upper "BIGSERIAL")   "bigserial"
       ;; Unsigned integers: upcast to avoid overflow (matches CL cast rules)
       (and unsigned? (str/starts-with? upper "TINYINT"))   "smallint"
@@ -74,10 +79,11 @@
       (str/starts-with? upper "ENUM")        "text"
       (str/starts-with? upper "SET")         "text[]"
       (str/starts-with? upper "JSON")        "jsonb"
-      (str/starts-with? upper "TIMESTAMP")   "timestamptz"
-      (str/starts-with? upper "DATETIME")    "timestamptz"
+      ;; Preserve precision modifier for temporal types: datetime(6) → timestamptz(6) (#1629)
+      (str/starts-with? upper "TIMESTAMP")   (str "timestamptz" (or typemod ""))
+      (str/starts-with? upper "DATETIME")    (str "timestamptz" (or typemod ""))
       (str/starts-with? upper "DATE")        "date"
-      (str/starts-with? upper "TIME")        "time"
+      (str/starts-with? upper "TIME")        (str "time" (or typemod ""))
       (str/starts-with? upper "YEAR")        "smallint"
       ;; Spatial types — requires PostGIS on the target.
       ;; The docker-compose postgres image includes PostGIS.
@@ -110,25 +116,35 @@
         default))))
 
 (defn- format-default
-  "Format a default value, quoting bare string literals for PostgreSQL."
+  "Format a default value, quoting bare string literals for PostgreSQL.
+   Handles:
+   - MySQL bit literals b'0'/b'1' → pass through (#1280)
+   - current_timestamp(N) with precision → current_timestamp (#1403)
+   - backslash in string defaults → escape as '' (#1546)"
   [^String val]
   (let [upper (str/upper-case val)
-        ;; Strip trailing () for comparison (PG doesn't accept () on these)
-        stripped (clojure.string/replace upper #"\(\)$" "")]
+        ;; Strip trailing () or (N) for comparison (PG doesn't accept those on keywords)
+        stripped (str/replace upper #"\(\d*\)$" "")]
     (cond
       ;; Numeric: don't quote
       (re-matches #"^-?\d+(\.\d+)?$" val) val
-      ;; Bit literal like B'0' or X'0F': pass through as-is (valid PG syntax)
-      (re-matches #"(?i)^[BX]'.*'$" val) val
-      ;; Known PostgreSQL keywords/functions: don't quote, strip ()
+      ;; Bit literal b'0', b'1', B'0', B'1': pass through as-is (#1280)
+      (re-matches #"(?i)^b'[01]+'$" val) val
+      ;; Hex literal X'0F': pass through as-is (valid PG syntax)
+      (re-matches #"(?i)^[X]'.*'$" val) val
+      ;; Known PostgreSQL keywords/functions: don't quote, strip precision (#1403)
       (#{"CURRENT_TIMESTAMP" "CURRENT_DATE" "CURRENT_TIME"
          "LOCALTIMESTAMP" "LOCALTIME" "TRUE" "FALSE"
          "NOW"}
        stripped) (str/lower-case stripped)
-      ;; Bare identifier (word): quote as string literal
+      ;; Bare identifier (word): quote as string literal with backslash escaping (#1546)
       (re-matches #"^\w+$" val) (str "'" (str/replace val "'" "''") "'")
-      ;; Anything else: quote as string literal
-      :else (str "'" (str/replace val "'" "''") "'"))))
+      ;; Anything else: quote as string literal; escape single quotes and backslashes (#1546)
+      :else (str "'"
+                 (-> val
+                     (str/replace "\\" "\\\\")
+                     (str/replace "'" "''"))
+                 "'"))))
 
 (defn- strip-quotes
   "Strip surrounding single or double quotes, repeatedly, until stable."
@@ -458,6 +474,20 @@
                         (:columns t))]
             (assoc t :columns new-cols :enum-types (vec enum-types))))
         catalog))
+
+(defn create-check-constraints-sql
+  "Generate ALTER TABLE ADD CONSTRAINT ... CHECK (...) statements.
+   Each check entry: {:constraint-name s :check-clause s}
+   MySQL 8.0.16+ exposes CHECK constraints in information_schema.CHECK_CONSTRAINTS.
+   Returns a vector of SQL strings."
+  [schema table-name checks]
+  (mapv (fn [ck]
+          (let [quoted-table (quote-fqname schema table-name)
+                ck-name      (identifier-quote (:constraint-name ck))]
+            (str "ALTER TABLE " quoted-table
+                 " ADD CONSTRAINT " ck-name
+                 " CHECK (" (:check-clause ck) ");")))
+        checks))
 
 (defn create-enum-types-sql
   "Generate DROP TYPE IF EXISTS + CREATE TYPE statements for ENUM/SET columns."

--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -487,11 +487,16 @@
         (keep (fn [ck]
                 (let [clause (:check-clause ck)]
                   (when (and (string? clause) (not (str/blank? clause)))
-                    (let [quoted-table (quote-fqname schema table-name)
+                    (let [;; MySQL 8 returns check clauses with backtick-quoted
+                          ;; identifiers (e.g. `salary` > 0). Replace backtick
+                          ;; quoting with PostgreSQL double-quote quoting so the
+                          ;; clause is valid SQL in PostgreSQL.
+                          pg-clause    (str/replace clause "`" "\"")
+                          quoted-table (quote-fqname schema table-name)
                           ck-name      (identifier-quote (:constraint-name ck))]
                       (str "ALTER TABLE " quoted-table
                            " ADD CONSTRAINT " ck-name
-                           " CHECK (" clause ");"))))))
+                           " CHECK (" pg-clause ");"))))))
         checks))
 
 (defn create-enum-types-sql

--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -481,12 +481,15 @@
    MySQL 8.0.16+ exposes CHECK constraints in information_schema.CHECK_CONSTRAINTS.
    Returns a vector of SQL strings."
   [schema table-name checks]
-  (mapv (fn [ck]
-          (let [quoted-table (quote-fqname schema table-name)
-                ck-name      (identifier-quote (:constraint-name ck))]
-            (str "ALTER TABLE " quoted-table
-                 " ADD CONSTRAINT " ck-name
-                 " CHECK (" (:check-clause ck) ");")))
+  (into []
+        (keep (fn [ck]
+                (let [clause (:check-clause ck)]
+                  (when (and (string? clause) (not (str/blank? clause)))
+                    (let [quoted-table (quote-fqname schema table-name)
+                          ck-name      (identifier-quote (:constraint-name ck))]
+                      (str "ALTER TABLE " quoted-table
+                           " ADD CONSTRAINT " ck-name
+                           " CHECK (" clause ");"))))))
         checks))
 
 (defn create-enum-types-sql

--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -185,10 +185,12 @@
       (str "  " quoted-name " " pg-type
            " GENERATED ALWAYS AS (" generated-expression ") STORED")
       (let [zero? (zero-date? col)
-            coerced-default (coerce-default-for-type
-                             (when column-default (strip-quotes (str column-default)))
-                             pg-type
-                             (:cast-fn col))
+            ;; MariaDB information_schema returns the string "NULL" (not SQL NULL)
+            ;; for columns with no explicit default. Filter it out before calling
+            ;; coerce-default-for-type so cast functions are not applied to "NULL".
+            raw-default (when (and column-default (not= "NULL" (str column-default)))
+                          (strip-quotes (str column-default)))
+            coerced-default (coerce-default-for-type raw-default pg-type (:cast-fn col))
             temporal-int-default? (and coerced-default
                                        (re-find #"(?i)^(timestamp|date|time)" (or pg-type ""))
                                        (re-matches #"^-?\d+$" (str coerced-default)))

--- a/clojure/src/pgloader/load_file/ast.clj
+++ b/clojure/src/pgloader/load_file/ast.clj
@@ -263,7 +263,6 @@
                              col (second (first (filter #(= :column-name (first %)) parts)))]
                          {:type :column :table tbl :column col})))
                    source)
-          without-type? (some #(= :without-type (first %)) inner-children)
           ;; Unwrap [:cast-option [...]] wrappers so option tag nodes are at top level
           flat-cast-opts (mapcat (fn [n]
                                    (if (and (vector? n) (= :cast-option (first n)))
@@ -310,7 +309,6 @@
           drop-opts (parse-cast-options (map first flat-cast-opts))]
       (cond-> {:target-type target}
         source (assoc :source source)
-        without-type? (assoc :without-type true)
         (seq drop-opts) (assoc :options drop-opts)
         using-fn (assoc :using using-fn)
         when-cond (merge when-cond)))))

--- a/clojure/src/pgloader/load_file/ast.clj
+++ b/clojure/src/pgloader/load_file/ast.clj
@@ -263,6 +263,13 @@
                              col (second (first (filter #(= :column-name (first %)) parts)))]
                          {:type :column :table tbl :column col})))
                    source)
+          without-type? (some #(= :without-type (first %)) inner-children)
+          ;; Unwrap [:cast-option [...]] wrappers so option tag nodes are at top level
+          flat-cast-opts (mapcat (fn [n]
+                                   (if (and (vector? n) (= :cast-option (first n)))
+                                     (rest n)
+                                     [n]))
+                                 inner-children)
           target-node (first (filter #(= :target-type-name (first %)) inner-children))
           target (when target-node
                    (let [target-inner (second target-node)]
@@ -273,7 +280,7 @@
                            (when (and (vector? n) (= :using-fn (first n)))
                              (keyword (second (some #(when (and (vector? %) (= :fn-name (first %))) %)
                                                     (rest n))))))
-                         inner-children)
+                         flat-cast-opts)
           when-node (first (filter #(= :when-or-unsigned (first %)) inner-children))
           when-cond (when when-node
                       (let [wc (vec (rest when-node))]
@@ -300,9 +307,10 @@
                                                (second c)))
                                            (rest we))]
                             {:when-extra (clojure.string/join "" parts)}))))
-          drop-opts (parse-cast-options inner-children)]
+          drop-opts (parse-cast-options (map first flat-cast-opts))]
       (cond-> {:target-type target}
         source (assoc :source source)
+        without-type? (assoc :without-type true)
         (seq drop-opts) (assoc :options drop-opts)
         using-fn (assoc :using using-fn)
         when-cond (merge when-cond)))))

--- a/clojure/src/pgloader/load_file/grammar.clj
+++ b/clojure/src/pgloader/load_file/grammar.clj
@@ -251,8 +251,9 @@
                   (<ws> <'to'> <ws> target-type-name)?
                   (<ws> cast-option)*
     column-cast = <'column'> <ws> column-ref
-                  <ws> <'to'> <ws> target-type-name
+                  (<ws> <'to'> <ws> target-type-name | <ws> without-type)
                   (<ws> cast-option)*
+    without-type = <'WITHOUT'> <ws> <'TYPE'>
     cast-option = drop-not-null | drop-default | set-not-null | keep-not-null
                 | drop-typemod | keep-typemod | drop-extra | using-fn
     drop-not-null = <'drop'> <ws> <'not'> <ws> <'null'>

--- a/clojure/src/pgloader/load_file/grammar.clj
+++ b/clojure/src/pgloader/load_file/grammar.clj
@@ -251,9 +251,8 @@
                   (<ws> <'to'> <ws> target-type-name)?
                   (<ws> cast-option)*
     column-cast = <'column'> <ws> column-ref
-                  (<ws> <'to'> <ws> target-type-name | <ws> without-type)
+                  (<ws> <'to'> <ws> target-type-name)?
                   (<ws> cast-option)*
-    without-type = <'WITHOUT'> <ws> <'TYPE'>
     cast-option = drop-not-null | drop-default | set-not-null | keep-not-null
                 | drop-typemod | keep-typemod | drop-extra | using-fn
     drop-not-null = <'drop'> <ws> <'not'> <ws> <'null'>

--- a/clojure/src/pgloader/regress.clj
+++ b/clojure/src/pgloader/regress.clj
@@ -5,9 +5,11 @@
    psql reads standard PG env vars (PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD).
 
    Usage:
-     java -jar pgloader.jar regress [--update] <suite-dir>
+     java -jar pgloader.jar regress [--update] [--variant <name>] <suite-dir>
 
-   --update  write out/ → expected/ instead of diffing (baseline registration)"
+   --update          write out/ → expected/ instead of diffing (baseline registration)
+   --variant <name>  prefer expected/<stem>.<name>.out over expected/<stem>.out;
+                     --update with --variant writes to the variant file"
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str])
@@ -60,18 +62,38 @@
             (print out)
             false)))))
 
+(defn- expected-file
+  "Resolve the expected file for a given stem, honouring --variant.
+   When variant is non-nil, prefer <exp-dir>/<stem>.<variant>.out and fall
+   back to <exp-dir>/<stem>.out when the variant file does not exist."
+  [^File exp-dir stem variant]
+  (if variant
+    (let [vf (io/file exp-dir (str stem "." variant ".out"))]
+      (if (.exists vf) vf (io/file exp-dir (str stem ".out"))))
+    (io/file exp-dir (str stem ".out"))))
+
 (defn run
   "Entry point called from cli/run when first arg is 'regress'."
   [args]
   (let [update?   (boolean (some #{"--update"} args))
+        variant   (->> (partition-all 2 1 args)
+                       (some (fn [[a b]] (when (= "--variant" a) b))))
         excludes  (->> args
                        (partition-all 2 1)
-                       (keep (fn [[a b]] (when (= "--update" a) nil)
+                       (keep (fn [[a b]]
                                (when (= "--exclude" a) b)))
                        (remove nil?)
                        set)
+        ;; Strip flags and their values so only positional args remain.
+        flag-values (into #{} (keep-indexed
+                               (fn [i _]
+                                 (when (contains? #{"--variant" "--exclude"}
+                                                  (nth args i nil))
+                                   (nth args (inc i) nil)))
+                               args))
         plain     (remove #(or (str/starts-with? % "--")
-                               (contains? excludes %)) args)
+                               (contains? excludes %)
+                               (contains? flag-values %)) args)
         dir-arg   (first plain)
         suite-dir (io/file (or dir-arg "."))
         exp-dir   (io/file suite-dir "expected")
@@ -88,7 +110,11 @@
              (fn [^File sql-file]
                (let [s        (stem sql-file)
                      out-file (io/file out-dir (str s ".out"))
-                     exp-file (io/file exp-dir (str s ".out"))]
+                     exp-file (expected-file exp-dir s variant)
+                     ;; When updating with a variant, always write the variant file.
+                     upd-file (if (and update? variant)
+                                (io/file exp-dir (str s "." variant ".out"))
+                                exp-file)]
                  (let [exit (run-psql sql-file out-file)]
                    (if (pos? exit)
                      (do (println (str "  ERROR    " s
@@ -96,8 +122,9 @@
                          (when (.exists out-file) (print (slurp out-file)))
                          false)
                      (if update?
-                       (do (io/copy out-file exp-file)
-                           (println (str "  updated  " s))
+                       (do (io/copy out-file upd-file)
+                           (println (str "  updated  " s
+                                         (when variant (str " [" variant "]"))))
                            true)
                        (diff-files exp-file out-file s))))))
              files)]

--- a/clojure/src/pgloader/source/mysql.clj
+++ b/clojure/src/pgloader/source/mysql.clj
@@ -130,9 +130,20 @@
       (conj! (nth buckets (mod i n)) item))
     (mapv persistent! buckets)))
 
+(defn- text-col-type?
+  "Return true for MySQL column types that hold character data and may contain
+   embedded NUL bytes (0x00) which JDBC getString() silently truncates (#1573)."
+  [^String raw-col-type]
+  (when raw-col-type
+    (let [lower (str/lower-case raw-col-type)]
+      (some #(str/starts-with? lower %)
+            ["char" "varchar" "tinytext" "mediumtext" "longtext" "text"]))))
+
 (defn- convert-mysql-value
-  "Convert a raw JDBC value from MySQL to a String suitable for COPY TEXT."
-  [v jdbc-type col]
+  "Convert a raw JDBC value from MySQL to a String suitable for COPY TEXT.
+   For text columns, reads bytes directly and re-encodes as UTF-8 to preserve
+   embedded NUL bytes that JDBC getString() would silently truncate (#1573)."
+  [v jdbc-type col ^java.sql.ResultSet rs col-idx]
   (when (some? v)
     (let [raw-col-type (:column-type col)]
       (cond
@@ -152,6 +163,11 @@
           (.append sb \X)
           (doseq [b ba] (.append sb (format "%02x" (bit-and (int b) 0xff))))
           (.toString sb))
+        ;; Text columns: use getBytes to preserve embedded NUL bytes (#1573)
+        (and (instance? String v) (text-col-type? raw-col-type))
+        (let [ba (.getBytes rs (int col-idx))]
+          (when (some? ba)
+            (String. ba java.nio.charset.StandardCharsets/UTF_8)))
         :else (str v)))))
 
 (defn- mysql-select-sql
@@ -207,7 +223,8 @@
                                                (convert-mysql-value
                                                 (.getObject rs i)
                                                 (nth jtypes (dec i))
-                                                (nth columns (dec i) nil))))
+                                                (nth columns (dec i) nil)
+                                                rs i)))
                                  (persistent! result)))
                              (next-row)))
                       ;; RS exhausted — open next range
@@ -258,7 +275,13 @@
                                                        :table (:table_name t)}))
                           fks   (table-fkeys conn
                                              {:schema schema-name
-                                              :table (:table_name t)})]
+                                              :table (:table_name t)})
+                          ;; CHECK constraints: MySQL 8.0.16+; empty on older versions
+                          checks (try
+                                   (table-checks conn {:schema schema-name
+                                                       :table (:table_name t)})
+                                   (catch Exception _
+                                     []))]
                       {:table-name        table-name
                        :source-table-name (:table_name t)
                        :schema            schema-name
@@ -296,7 +319,11 @@
                                                              (str/split (:fcols fk) #","))
                                             :on-delete (:delete_rule fk)
                                             :on-update (:update_rule fk)})
-                                         fks)})))
+                                         fks)
+                       :checks     (mapv (fn [ck]
+                                           {:constraint-name (:constraint_name ck)
+                                            :check-clause    (:check_clause ck)})
+                                         checks)})))
              (filter (fn [t]
                        (if-let [filter-fn (:table-filter table-spec)]
                          (filter-fn (:table-name t))

--- a/clojure/src/pgloader/source/mysql.clj
+++ b/clojure/src/pgloader/source/mysql.clj
@@ -163,11 +163,11 @@
           (.append sb \X)
           (doseq [b ba] (.append sb (format "%02x" (bit-and (int b) 0xff))))
           (.toString sb))
-        ;; Text columns: use getBytes to preserve embedded NUL bytes (#1573)
+        ;; Text columns: use getString so the JDBC driver applies charset
+        ;; conversion correctly (#1573). getString preserves NUL bytes in
+        ;; MySQL Connector/J; getObject may truncate at the first NUL.
         (and (instance? String v) (text-col-type? raw-col-type))
-        (let [ba (.getBytes rs (int col-idx))]
-          (when (some? ba)
-            (String. ba java.nio.charset.StandardCharsets/UTF_8)))
+        (.getString rs (int col-idx))
         :else (str v)))))
 
 (defn- mysql-select-sql

--- a/clojure/src/pgloader/source/mysql.sql
+++ b/clojure/src/pgloader/source/mysql.sql
@@ -103,6 +103,18 @@ SELECT tc.constraint_name                 AS constraint_name,
    AND k.referenced_table_schema = :schema
  GROUP BY tc.constraint_name, k.referenced_table_name, rc.update_rule, rc.delete_rule
 
+-- :name table-checks :? :*
+-- :doc CHECK constraints for a table (MySQL 8.0.16+; returns empty on older versions)
+SELECT cc.CONSTRAINT_NAME  AS constraint_name,
+       cc.CHECK_CLAUSE      AS check_clause
+  FROM information_schema.TABLE_CONSTRAINTS tc
+  JOIN information_schema.CHECK_CONSTRAINTS cc
+    ON cc.CONSTRAINT_SCHEMA = tc.TABLE_SCHEMA
+   AND cc.CONSTRAINT_NAME   = tc.CONSTRAINT_NAME
+ WHERE tc.TABLE_SCHEMA      = :schema
+   AND tc.TABLE_NAME        = :table
+   AND tc.CONSTRAINT_TYPE   = 'CHECK'
+
 -- :name table-avg-row-length :? :1
 -- :doc AVG_ROW_LENGTH estimate from information_schema for chunk-size calculation
 SELECT COALESCE(AVG_ROW_LENGTH, 0) AS avg_row_length

--- a/clojure/test/pgloader/cast_test.clj
+++ b/clojure/test/pgloader/cast_test.clj
@@ -186,22 +186,20 @@
             result (cast/apply-type-overrides columns rules)]
         (is (= ["varchar"] (mapv :column-type result))))))
 
-  (deftest test-without-type-cast
-    (testing "without-type rule matches column but does not change type (#1522)"
+  (deftest test-column-cast-no-type
+    (testing "column cast without 'to TYPE' does not change type (#1522)"
       (let [rules [{:source {:type :column :column "status"}
-                    :without-type true
+                    :target-type nil
                     :using :set-to-enum-array}]
             columns [{:column-name "status" :column-type "enum('a','b')"}
                      {:column-name "name"   :column-type "varchar(100)"}]
             overridden (cast/apply-type-overrides columns rules)]
-      ;; Type should NOT change
         (is (= "enum('a','b')" (:column-type (first overridden))))
-      ;; But cast-fn should be set
         (is (= :set-to-enum-array (:cast-fn (first overridden))))))
 
-    (testing "without-type resolve-specs picks up the using fn"
+    (testing "column cast without 'to TYPE' resolve-specs picks up the using fn"
       (let [rules [{:source {:type :column :column "status"}
-                    :without-type true
+                    :target-type nil
                     :using :set-to-enum-array}]
             columns [{:column-name "status" :column-type "enum('a','b')"}]
             specs (cast/resolve-specs rules columns)]

--- a/clojure/test/pgloader/cast_test.clj
+++ b/clojure/test/pgloader/cast_test.clj
@@ -147,4 +147,62 @@
           result (cast/apply-type-overrides columns rules)]
       (is (= ["text" "int"] (mapv :column-type result)))
       ;; source type preserved so resolve-specs can still match on original
-      (is (= "char(3)" (:source-column-type (first result)))))))
+      (is (= "char(3)" (:source-column-type (first result))))))
+
+;; ── New PR-1/PR-2 cast fixes ──────────────────────────────────────────────────
+
+  (deftest test-hex-to-bytea
+    (testing "plain hex string (#1066)"
+      (is (= "\\xdeadbeef" (cast/hex-to-bytea "DEADBEEF"))))
+    (testing "0x prefix stripped"
+      (is (= "\\xcafe" (cast/hex-to-bytea "0xCAFE"))))
+    (testing "\\x prefix stripped"
+      (is (= "\\x01ff" (cast/hex-to-bytea "\\x01FF"))))
+    (testing "nil input"
+      (is (nil? (cast/hex-to-bytea nil)))))
+
+  (deftest test-hex-to-bytea-in-registry
+    (testing "hex-to-bytea is in cast registry and works via apply-cast"
+      (is (= "\\xdeadbeef" (cast/apply-cast :hex-to-bytea "DEADBEEF")))))
+
+  (deftest test-int-to-uuid-in-registry
+    (testing "int-to-uuid is registered and converts integers (#1457)"
+      (let [result (cast/apply-cast :int-to-uuid "0")]
+        (is (= "00000000-0000-0000-0000-000000000000" result)))))
+
+  (deftest test-char-cast-prefix-match
+    (testing "type char cast rule matches char(N) via prefix (#1525)"
+      (let [rules [{:source {:type :type :name "char"} :target-type "text"
+                    :options {:drop-typemod true}}]
+            columns [{:column-name "code" :column-type "char(3)"}
+                     {:column-name "flag" :column-type "char(1)"}]
+            result (cast/apply-type-overrides columns rules)]
+        (is (= ["text" "text"] (mapv :column-type result)))))
+
+    (testing "char(1) matched by 'char' rule (char without parens)"
+      (let [rules [{:source {:type :type :name "char"} :target-type "varchar"
+                    :options {:drop-typemod false}}]
+            columns [{:column-name "x" :column-type "char"}]
+            result (cast/apply-type-overrides columns rules)]
+        (is (= ["varchar"] (mapv :column-type result))))))
+
+  (deftest test-without-type-cast
+    (testing "without-type rule matches column but does not change type (#1522)"
+      (let [rules [{:source {:type :column :column "status"}
+                    :without-type true
+                    :using :set-to-enum-array}]
+            columns [{:column-name "status" :column-type "enum('a','b')"}
+                     {:column-name "name"   :column-type "varchar(100)"}]
+            overridden (cast/apply-type-overrides columns rules)]
+      ;; Type should NOT change
+        (is (= "enum('a','b')" (:column-type (first overridden))))
+      ;; But cast-fn should be set
+        (is (= :set-to-enum-array (:cast-fn (first overridden))))))
+
+    (testing "without-type resolve-specs picks up the using fn"
+      (let [rules [{:source {:type :column :column "status"}
+                    :without-type true
+                    :using :set-to-enum-array}]
+            columns [{:column-name "status" :column-type "enum('a','b')"}]
+            specs (cast/resolve-specs rules columns)]
+        (is (= [:set-to-enum-array] specs))))))

--- a/clojure/test/pgloader/ddl_test.clj
+++ b/clojure/test/pgloader/ddl_test.clj
@@ -250,3 +250,96 @@
           no-drop (remove #(str/starts-with? % "DROP") sqls)]
       (is (= 1 (count no-drop)))
       (is (str/starts-with? (first no-drop) "CREATE TYPE")))))
+
+;; ── MySQL type mapping (#1629, #1280, #1403, #1546, #1371) ───────────────────
+
+(deftest test-pg-type-for-timestamp-precision
+  (testing "datetime(6) preserves precision as timestamptz(6) (#1629)"
+    (let [col {:column-name "created_at" :column-type "datetime(6)"
+               :is-nullable true :extra "" :column-default nil}
+          sql (ddl/column-def col)]
+      (is (str/includes? sql "timestamptz(6)"))))
+
+  (testing "timestamp(3) preserves precision (#1629)"
+    (let [col {:column-name "ts" :column-type "timestamp(3)"
+               :is-nullable true :extra "" :column-default nil}
+          sql (ddl/column-def col)]
+      (is (str/includes? sql "timestamptz(3)"))))
+
+  (testing "datetime without precision stays timestamptz"
+    (let [col {:column-name "ts" :column-type "datetime"
+               :is-nullable true :extra "" :column-default nil}
+          sql (ddl/column-def col)]
+      (is (str/includes? sql "timestamptz"))
+      (is (not (str/includes? sql "timestamptz(")))))
+
+  (testing "array types from PG source pass through unchanged (#1371)"
+    (let [col {:column-name "tags" :column-type "varchar[]"
+               :is-nullable true :extra "" :column-default nil}
+          sql (ddl/column-def col)]
+      (is (str/includes? sql "varchar[]")))))
+
+(deftest test-column-def-defaults
+  (testing "bit(1) DEFAULT b'0' passes through as bit literal (#1280)"
+    (let [col {:column-name "flag" :column-type "bit(1)"
+               :is-nullable false :extra "" :column-default "b'0'"}
+          sql (ddl/column-def col)]
+      (is (str/includes? sql "DEFAULT b'0'"))))
+
+  (testing "current_timestamp(6) DEFAULT strips precision for PG (#1403)"
+    (let [col {:column-name "ts" :column-type "datetime(6)"
+               :is-nullable true :extra ""
+               :column-default "current_timestamp(6)"}
+          sql (ddl/column-def col)]
+      (is (str/includes? sql "DEFAULT current_timestamp"))
+      (is (not (str/includes? sql "current_timestamp(6)")))))
+
+  (testing "backslash in default value is escaped (#1546)"
+    (let [col {:column-name "path" :column-type "varchar(255)"
+               :is-nullable true :extra "" :column-default "C:\\Users"}
+          sql (ddl/column-def col)]
+      (is (str/includes? sql "DEFAULT 'C:\\\\Users'"))))
+
+  (testing "ON UPDATE CURRENT_TIMESTAMP trigger generated (#1560/#1196)"
+    (let [cols [{:column-name "updated_at" :column-type "datetime"
+                 :is-nullable true :extra "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
+                 :column-default "CURRENT_TIMESTAMP"}]]
+      (let [sqls (ddl/create-triggers-sql "public" "orders" cols)]
+        (is (some? sqls))
+        (is (= 2 (count sqls)))
+        (is (str/includes? (first sqls) "CREATE OR REPLACE FUNCTION")))))
+
+  (testing "ON UPDATE CURRENT_TIMESTAMP with no DEFAULT also creates trigger (#1196)"
+    (let [cols [{:column-name "upd" :column-type "timestamp"
+                 :is-nullable true :extra "on update CURRENT_TIMESTAMP"
+                 :column-default nil}]]
+      (let [sqls (ddl/create-triggers-sql "myschema" "t" cols)]
+        (is (some? sqls))
+        (is (str/includes? (second sqls) "BEFORE UPDATE"))))))
+
+(deftest test-check-constraints-sql
+  (testing "generates ALTER TABLE ADD CONSTRAINT CHECK (#1645)"
+    (let [sqls (ddl/create-check-constraints-sql "public" "employees"
+                                                 [{:constraint-name "chk_salary"
+                                                   :check-clause "salary > 0"}
+                                                  {:constraint-name "chk_dept"
+                                                   :check-clause "dept IN ('HR','Eng')"}])]
+      (is (= 2 (count sqls)))
+      (is (str/includes? (first sqls) "ADD CONSTRAINT \"chk_salary\" CHECK (salary > 0)"))
+      (is (str/includes? (second sqls) "ADD CONSTRAINT \"chk_dept\" CHECK"))))
+
+  (testing "empty checks returns empty vector"
+    (is (= [] (ddl/create-check-constraints-sql "public" "t" [])))))
+
+(deftest test-enum-type-name-after-alter-table-rename
+  (testing "ENUM type name uses renamed table name (#1564)"
+    (let [cat [{:table-name "renamed_tbl"
+                :schema     "public"
+                :columns    [{:column-name "status"
+                              :column-type "enum('active','inactive')"}]
+                :primary-key [] :indexes [] :fkeys []}]
+          result (ddl/add-enum-types cat)]
+      (let [enum-types (:enum-types (first result))]
+        (is (= 1 (count enum-types)))
+        ;; type name uses the (already-renamed) table name
+        (is (= "renamed_tbl_status" (:type-name (first enum-types))))))))

--- a/clojure/test/pgloader/ddl_test.clj
+++ b/clojure/test/pgloader/ddl_test.clj
@@ -328,6 +328,13 @@
       (is (str/includes? (first sqls) "ADD CONSTRAINT \"chk_salary\" CHECK (salary > 0)"))
       (is (str/includes? (second sqls) "ADD CONSTRAINT \"chk_dept\" CHECK"))))
 
+  (testing "MySQL 8 backtick-quoted identifiers converted to double-quote (#1645)"
+    (let [sqls (ddl/create-check-constraints-sql "public" "employees"
+                                                 [{:constraint-name "chk_salary"
+                                                   :check-clause "`salary` > 0"}])]
+      (is (= 1 (count sqls)))
+      (is (str/includes? (first sqls) "CHECK (\"salary\" > 0)"))))
+
   (testing "empty checks returns empty vector"
     (is (= [] (ddl/create-check-constraints-sql "public" "t" [])))))
 

--- a/clojure/test/pgloader/load_file/parser_test.clj
+++ b/clojure/test/pgloader/load_file/parser_test.clj
@@ -257,3 +257,49 @@
                     WITH uniquify index names;")]
       (is (:ok result))
       (is (true? (get-in result [:ok :with-options :uniquify-index-names]))))))
+
+;; ── Cast grammar fixes (#1522, #1273, #1470) ─────────────────────────────────
+
+(deftest test-cast-without-type
+  (testing "CAST column col WITHOUT TYPE parses successfully (#1522)"
+    (let [result (parser/parse-string
+                  "LOAD DATABASE FROM mysql://h/db INTO pgsql://h/t
+                    CAST column status WITHOUT TYPE;")]
+      (is (:ok result) (str "Parse error: " (:error result)))
+      (let [rules (get-in result [:ok :cast-rules])]
+        (is (= 1 (count rules)))
+        (is (true? (:without-type (first rules)))))))
+
+  (testing "CAST column col WITHOUT TYPE using fn parses with using (#1522)"
+    (let [result (parser/parse-string
+                  "LOAD DATABASE FROM mysql://h/db INTO pgsql://h/t
+                    CAST column status WITHOUT TYPE using set-to-enum-array;")]
+      (is (:ok result))
+      (let [rule (first (get-in result [:ok :cast-rules]))]
+        (is (:without-type rule))
+        (is (= :set-to-enum-array (:using rule)))))))
+
+(deftest test-cast-target-type-multi-word
+  (testing "multi-word target type like 'timestamp without time zone' parses (#1273)"
+    (let [result (parser/parse-string
+                  "LOAD DATABASE FROM mysql://h/db INTO pgsql://h/t
+                    CAST type timestamp to \"timestamp without time zone\";")]
+      (is (:ok result) (str "Parse error: " (:error result)))
+      (let [rule (first (get-in result [:ok :cast-rules]))]
+        (is (= "timestamp without time zone" (:target-type rule))))))
+
+  (testing "unquoted multi-word type like 'timestamp without time zone' parses (#1273)"
+    (let [result (parser/parse-string
+                  "LOAD DATABASE FROM mysql://h/db INTO pgsql://h/t
+                    CAST type timestamp to timestamp without time zone;")]
+      (is (:ok result) (str "Parse error: " (:error result)))
+      (let [rule (first (get-in result [:ok :cast-rules]))]
+        (is (= "timestamp without time zone" (:target-type rule))))))
+
+  (testing "timestamp to plain timestamp cast overrides default timestamptz (#1470)"
+    (let [result (parser/parse-string
+                  "LOAD DATABASE FROM mysql://h/db INTO pgsql://h/t
+                    CAST type timestamp to timestamp;")]
+      (is (:ok result) (str "Parse error: " (:error result)))
+      (let [rule (first (get-in result [:ok :cast-rules]))]
+        (is (= "timestamp" (:target-type rule)))))))

--- a/clojure/test/pgloader/load_file/parser_test.clj
+++ b/clojure/test/pgloader/load_file/parser_test.clj
@@ -260,24 +260,23 @@
 
 ;; ── Cast grammar fixes (#1522, #1273, #1470) ─────────────────────────────────
 
-(deftest test-cast-without-type
-  (testing "CAST column col WITHOUT TYPE parses successfully (#1522)"
+(deftest test-cast-column-no-type
+  (testing "CAST column col using fn (no 'to TYPE') parses successfully (#1522)"
     (let [result (parser/parse-string
                   "LOAD DATABASE FROM mysql://h/db INTO pgsql://h/t
-                    CAST column status WITHOUT TYPE;")]
+                    CAST column tbl.status using set-to-enum-array;")]
       (is (:ok result) (str "Parse error: " (:error result)))
-      (let [rules (get-in result [:ok :cast-rules])]
-        (is (= 1 (count rules)))
-        (is (true? (:without-type (first rules)))))))
+      (let [rule (first (get-in result [:ok :cast-rules]))]
+        (is (nil? (:target-type rule)))
+        (is (= :set-to-enum-array (:using rule))))))
 
-  (testing "CAST column col WITHOUT TYPE using fn parses with using (#1522)"
+  (testing "CAST column col (no 'to TYPE', no using) parses successfully"
     (let [result (parser/parse-string
                   "LOAD DATABASE FROM mysql://h/db INTO pgsql://h/t
-                    CAST column status WITHOUT TYPE using set-to-enum-array;")]
-      (is (:ok result))
+                    CAST column tbl.status drop not null;")]
+      (is (:ok result) (str "Parse error: " (:error result)))
       (let [rule (first (get-in result [:ok :cast-rules]))]
-        (is (:without-type rule))
-        (is (= :set-to-enum-array (:using rule)))))))
+        (is (nil? (:target-type rule)))))))
 
 (deftest test-cast-target-type-multi-word
   (testing "multi-word target type like 'timestamp without time zone' parses (#1273)"

--- a/clojure/tests/Makefile
+++ b/clojure/tests/Makefile
@@ -175,7 +175,7 @@ mysql: ensure-jar ensure-f1db
 mysql-v3: ensure-jar ensure-f1db
 	@$(DC) -f mysql/docker-compose.yml down --volumes 2>/dev/null; true
 	$(DC) $(PROFILE) -f mysql/docker-compose.yml run --rm --build \
-	  -e "PGLOADER_CMD=pgloader --client-min-messages notice" test-runner make all-v3
+	  -e "PGLOADER_CMD=pgloader --client-min-messages notice" test-runner make -C /suite all-v3
 	@$(DC) -f mysql/docker-compose.yml down --volumes 2>/dev/null; true
 
 # ─── Suite: mysql57 ───────────────────────────────────────────────────────────
@@ -206,7 +206,7 @@ mariadb: ensure-jar ensure-f1db
 mariadb-v3: ensure-jar ensure-f1db
 	@$(DC) -f mariadb/docker-compose.yml down --volumes 2>/dev/null; true
 	$(DC) $(PROFILE) -f mariadb/docker-compose.yml run --rm --build \
-	  -e "PGLOADER_CMD=pgloader --client-min-messages notice" test-runner
+	  -e "PGLOADER_CMD=pgloader --client-min-messages notice" test-runner make -C /suite all-v3
 	@$(DC) -f mariadb/docker-compose.yml down --volumes 2>/dev/null; true
 
 # ─── Suite: pgsql ─────────────────────────────────────────────────────────────

--- a/clojure/tests/Makefile
+++ b/clojure/tests/Makefile
@@ -175,7 +175,7 @@ mysql: ensure-jar ensure-f1db
 mysql-v3: ensure-jar ensure-f1db
 	@$(DC) -f mysql/docker-compose.yml down --volumes 2>/dev/null; true
 	$(DC) $(PROFILE) -f mysql/docker-compose.yml run --rm --build \
-	  -e "PGLOADER_CMD=pgloader --client-min-messages notice" test-runner
+	  -e "PGLOADER_CMD=pgloader --client-min-messages notice" test-runner make all-v3
 	@$(DC) -f mysql/docker-compose.yml down --volumes 2>/dev/null; true
 
 # ─── Suite: mysql57 ───────────────────────────────────────────────────────────

--- a/clojure/tests/mariadb/Dockerfile
+++ b/clojure/tests/mariadb/Dockerfile
@@ -25,6 +25,9 @@ COPY test/mysql/db789.sql    /docker-entrypoint-initdb.d/db789.sql
 # === pgloader integration test seed (source + source2 databases) ===
 COPY clojure/tests/mariadb/data/seed.sql /docker-entrypoint-initdb.d/seed.sql
 
+# === mysql-unit-full test schema (pgloader_mysql_unit_full database) ===
+COPY clojure/tests/mysql-unit-full/mysql-unit-full.sql /docker-entrypoint-initdb.d/mysql-unit-full.sql
+
 # === Init script ===
 # .sql files renamed to .tmpl to prevent MariaDB auto-running them.
 # Our shell script creates the correct databases first, then sources the .tmpl files.
@@ -37,4 +40,5 @@ RUN chmod +x /docker-entrypoint-initdb.d/load-datasets.sh \
   && mv /docker-entrypoint-initdb.d/my.sql        /docker-entrypoint-initdb.d/my.tmpl \
   && mv /docker-entrypoint-initdb.d/history.sql   /docker-entrypoint-initdb.d/history.tmpl \
   && mv /docker-entrypoint-initdb.d/db789.sql     /docker-entrypoint-initdb.d/db789.tmpl \
-  && mv /docker-entrypoint-initdb.d/seed.sql      /docker-entrypoint-initdb.d/seed.tmpl
+  && mv /docker-entrypoint-initdb.d/seed.sql      /docker-entrypoint-initdb.d/seed.tmpl \
+  && mv /docker-entrypoint-initdb.d/mysql-unit-full.sql /docker-entrypoint-initdb.d/mysql-unit-full.tmpl

--- a/clojure/tests/mariadb/Makefile
+++ b/clojure/tests/mariadb/Makefile
@@ -2,9 +2,9 @@ JAR          ?= /pgloader.jar
 PGLOADER_CMD ?= java -jar $(JAR)
 REGRESS_FLAGS ?=
 
-.PHONY: all my sakila f1db
+.PHONY: all my sakila f1db mysql-unit-full
 
-all: my sakila f1db
+all: my sakila f1db mysql-unit-full
 
 my:
 	$(PGLOADER_CMD) my/my.load
@@ -18,6 +18,21 @@ f1db:
 	$(PGLOADER_CMD) f1db/f1db.load
 	java -jar $(JAR) regress $(REGRESS_FLAGS) f1db
 
+# mysql-unit-full: full v4 regression suite, always run with the v4 JAR.
+# Runs against MariaDB (MYSQL_HOST=mariadb set in docker-compose.yml).
+# Uses --variant mariadb so tests whose output differs from MySQL 8 (e.g.
+# CHECK constraints surfaced differently) match their own expected files,
+# while tests with identical output fall back to the shared baseline.
+mysql-unit-full:
+	java -jar $(JAR) mysql-unit-full/mysql-unit-full.load
+	java -jar $(JAR) regress $(REGRESS_FLAGS) --variant mariadb mysql-unit-full
+
+# all-v3 explicitly excludes mysql-unit-full: it tests v4-specific behaviour
+# and has no meaningful v3 equivalent.  The @: recipe prevents the %-v3
+# catch-all from appending its own recipe (make all PGLOADER_CMD=pgloader).
+all-v3: my-v3 sakila-v3 f1db-v3
+	@:
+
 %-v3:
 	$(MAKE) $* PGLOADER_CMD="pgloader --client-min-messages notice"
 
@@ -26,3 +41,6 @@ f1db:
 
 update-expected-%:
 	java -jar $(JAR) regress --update $*
+
+update-expected-mariadb-%:
+	java -jar $(JAR) regress --update --variant mariadb $*

--- a/clojure/tests/mariadb/data/load-datasets.sh
+++ b/clojure/tests/mariadb/data/load-datasets.sh
@@ -24,3 +24,7 @@ echo "db789 loaded successfully"
 echo "=== Loading pgloader integration seed (source, source2) ==="
 mariadb -u root -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/seed.tmpl
 echo "Seed loaded successfully"
+
+echo "=== Loading mysql-unit-full test schema (pgloader_mysql_unit_full) ==="
+mariadb -u root -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/mysql-unit-full.tmpl
+echo "mysql-unit-full test schema loaded successfully"

--- a/clojure/tests/mariadb/docker-compose.yml
+++ b/clojure/tests/mariadb/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_unicode_ci
     healthcheck:
-      test: ["CMD-SHELL", "mariadb -u root -prootpassword -e 'USE source; SELECT COUNT(*) FROM users' 2>/dev/null && mariadb -u root -prootpassword -e 'USE sakila; SELECT COUNT(*) FROM actor' 2>/dev/null && mariadb -u root -prootpassword -e 'USE f1db; SELECT COUNT(*) FROM circuits' 2>/dev/null"]
+      test: ["CMD-SHELL", "mariadb -u root -prootpassword -e 'USE source; SELECT COUNT(*) FROM users' 2>/dev/null && mariadb -u root -prootpassword -e 'USE sakila; SELECT COUNT(*) FROM actor' 2>/dev/null && mariadb -u root -prootpassword -e 'USE f1db; SELECT COUNT(*) FROM circuits' 2>/dev/null && mariadb -u root -prootpassword -e 'USE pgloader_mysql_unit_full; SELECT COUNT(*) FROM salary_check' 2>/dev/null"]
       interval: 10s
       timeout: 10s
       retries: 30
@@ -36,9 +36,11 @@ services:
       dockerfile: clojure/tests/Dockerfile
     volumes:
       - .:/suite
+      - ../mysql-unit-full:/suite/mysql-unit-full
       - ../../target/pgloader.jar:/pgloader.jar:ro
     environment:
       JAR: /pgloader.jar
+      MYSQL_HOST: mariadb
       PGHOST: postgres
       PGPORT: "5432"
       PGDATABASE: target

--- a/clojure/tests/mysql-unit-full/expected/01-tables.out
+++ b/clojure/tests/mysql-unit-full/expected/01-tables.out
@@ -1,0 +1,10 @@
+   table_name   
+----------------
+ bit_defaults
+ hex_binary
+ on_update_ts
+ salary_check
+ set_column
+ type_precision
+(6 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/02-datetime-precision.mariadb.out
+++ b/clojure/tests/mysql-unit-full/expected/02-datetime-precision.mariadb.out
@@ -1,0 +1,9 @@
+ column_name |        data_type         | datetime_precision |  column_default   
+-------------+--------------------------+--------------------+-------------------
+ id          | bigint                   |                    | 
+ ts6         | timestamp with time zone |                  6 | CURRENT_TIMESTAMP
+ ts3         | timestamp with time zone |                  3 | 
+ t3          | time without time zone   |                  3 | 
+ plain_ts    | timestamp with time zone |                  6 | CURRENT_TIMESTAMP
+(5 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/02-datetime-precision.out
+++ b/clojure/tests/mysql-unit-full/expected/02-datetime-precision.out
@@ -1,0 +1,9 @@
+ column_name |        data_type         | datetime_precision |  column_default   
+-------------+--------------------------+--------------------+-------------------
+ id          | integer                  |                    | 
+ ts6         | timestamp with time zone |                  6 | CURRENT_TIMESTAMP
+ ts3         | timestamp with time zone |                  3 | 
+ t3          | time without time zone   |                  3 | 
+ plain_ts    | timestamp with time zone |                  6 | CURRENT_TIMESTAMP
+(5 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/03-bit-defaults.mariadb.out
+++ b/clojure/tests/mysql-unit-full/expected/03-bit-defaults.mariadb.out
@@ -1,0 +1,8 @@
+ column_name |        data_type         |  column_default   
+-------------+--------------------------+-------------------
+ id          | bigint                   | 
+ flags       | bit varying              | '0'::"bit"
+ single_bit  | bit varying              | '0'::"bit"
+ created_at  | timestamp with time zone | CURRENT_TIMESTAMP
+(4 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/03-bit-defaults.out
+++ b/clojure/tests/mysql-unit-full/expected/03-bit-defaults.out
@@ -1,0 +1,8 @@
+ column_name |        data_type         |  column_default   
+-------------+--------------------------+-------------------
+ id          | integer                  | 
+ flags       | bit varying              | '0'::"bit"
+ single_bit  | bit varying              | '0'::"bit"
+ created_at  | timestamp with time zone | CURRENT_TIMESTAMP
+(4 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/04-check-constraints.out
+++ b/clojure/tests/mysql-unit-full/expected/04-check-constraints.out
@@ -1,0 +1,6 @@
+   constraint_name   |             check_clause              
+---------------------+---------------------------------------
+ chk_age_range       | CHECK (((age >= 18) AND (age <= 99)))
+ chk_salary_positive | CHECK ((salary > (0)::numeric))
+(2 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/05-on-update-trigger.out
+++ b/clojure/tests/mysql-unit-full/expected/05-on-update-trigger.out
@@ -1,0 +1,5 @@
+    trigger_name     | event_manipulation | action_timing 
+---------------------+--------------------+---------------
+ trg_on_update_ts_ts | UPDATE             | BEFORE
+(1 row)
+

--- a/clojure/tests/mysql-unit-full/expected/06-hex-to-bytea.out
+++ b/clojure/tests/mysql-unit-full/expected/06-hex-to-bytea.out
@@ -1,0 +1,7 @@
+  label   |  raw_hex   
+----------+------------
+ plain    | \xdeadbeef
+ prefixed | \xcafebabe
+ empty    | \x
+(3 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/07-without-type.mariadb.out
+++ b/clojure/tests/mysql-unit-full/expected/07-without-type.mariadb.out
@@ -1,0 +1,13 @@
+ column_name | data_type |     udt_name      
+-------------+-----------+-------------------
+ id          | bigint    | int8
+ perms       | ARRAY     | _set_column_perms
+(2 rows)
+
+ id |        perms         
+----+----------------------
+  1 | {read}
+  2 | {read,write}
+  3 | {read,write,execute}
+(3 rows)
+

--- a/clojure/tests/mysql-unit-full/expected/07-without-type.out
+++ b/clojure/tests/mysql-unit-full/expected/07-without-type.out
@@ -1,0 +1,13 @@
+ column_name | data_type |     udt_name      
+-------------+-----------+-------------------
+ id          | integer   | int4
+ perms       | ARRAY     | _set_column_perms
+(2 rows)
+
+ id |        perms         
+----+----------------------
+  1 | {read}
+  2 | {read,write}
+  3 | {read,write,execute}
+(3 rows)
+

--- a/clojure/tests/mysql-unit-full/mysql-unit-full.load
+++ b/clojure/tests/mysql-unit-full/mysql-unit-full.load
@@ -1,0 +1,34 @@
+-- Full integration test suite for the pgloader v4 Clojure rewrite.
+-- Exercises features not present or not complete in pgloader v3:
+--   #1629  datetime(N) precision preserved → timestamptz(N)
+--   #1403  CURRENT_TIMESTAMP(N) default stripped to keyword
+--   #1280  bit literal b'0' default passes through
+--   #1645  CHECK constraints migrated via ALTER TABLE ADD CONSTRAINT
+--   #1560/#1196  ON UPDATE CURRENT_TIMESTAMP → BEFORE UPDATE trigger
+--   #1066  hex-to-bytea cast function
+--   #1522  WITHOUT TYPE cast syntax
+--
+-- MYSQL_HOST is expanded from the environment (default: mysql).
+-- Set MYSQL_HOST=mariadb when running against the MariaDB suite.
+
+load database
+     from      mysql://root:rootpassword@{{MYSQL_HOST}}:3306/pgloader_mysql_unit_full?useSSL=false
+     into postgresql://pgloader:pgloader@postgres:5432/target
+
+ WITH create tables,
+      create indexes,
+      include drop,
+      quote identifiers
+
+ ALTER SCHEMA 'pgloader_mysql_unit_full' RENAME TO 'mysql_unit_full'
+
+ CAST
+      -- #1066 hex-to-bytea: load raw_hex column as PostgreSQL bytea
+      column hex_binary.raw_hex to bytea using hex-to-bytea,
+
+      -- #1522 WITHOUT TYPE: preserve the SET→enum-array mapping but route
+      -- the value through set-to-enum-array without changing the column type
+      column set_column.perms WITHOUT TYPE using set-to-enum-array
+
+ BEFORE LOAD DO
+   $$ CREATE SCHEMA IF NOT EXISTS mysql_unit_full; $$;

--- a/clojure/tests/mysql-unit-full/mysql-unit-full.load
+++ b/clojure/tests/mysql-unit-full/mysql-unit-full.load
@@ -26,9 +26,9 @@ load database
       -- #1066 hex-to-bytea: load raw_hex column as PostgreSQL bytea
       column hex_binary.raw_hex to bytea using hex-to-bytea,
 
-      -- #1522 WITHOUT TYPE: preserve the SET→enum-array mapping but route
-      -- the value through set-to-enum-array without changing the column type
-      column set_column.perms WITHOUT TYPE using set-to-enum-array
+      -- #1522 omitting 'to TYPE': preserve the SET→enum-array mapping, only
+      -- route the value through set-to-enum-array without changing the column type
+      column set_column.perms using set-to-enum-array
 
  BEFORE LOAD DO
    $$ CREATE SCHEMA IF NOT EXISTS mysql_unit_full; $$;

--- a/clojure/tests/mysql-unit-full/mysql-unit-full.sql
+++ b/clojure/tests/mysql-unit-full/mysql-unit-full.sql
@@ -1,0 +1,87 @@
+-- Full integration test seed for the pgloader v4 Clojure rewrite.
+-- Compatible with MySQL 8.0.16+ and MariaDB 10.2+.
+-- Loaded into `pgloader_mysql_unit_full` on both MySQL and MariaDB.
+
+CREATE DATABASE IF NOT EXISTS pgloader_mysql_unit_full;
+USE pgloader_mysql_unit_full;
+
+-- #1629: datetime/timestamp precision modifier preserved (datetime(6) → timestamptz(6))
+-- #1403: CURRENT_TIMESTAMP(6) default stripped to bare keyword
+CREATE TABLE type_precision (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  ts6         DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ts3         DATETIME(3)  DEFAULT NULL,
+  t3          TIME(3)      DEFAULT NULL,
+  plain_ts    DATETIME     DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO type_precision (ts3, t3) VALUES
+  ('2024-06-01 12:34:56.123', '01:02:03.456'),
+  ('2024-12-31 23:59:59.999', '23:59:59.999');
+
+-- #1280: bit(N) DEFAULT b'0' passes through as bit literal
+-- #1403: CURRENT_TIMESTAMP default is lowercased keyword (not quoted string)
+CREATE TABLE bit_defaults (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  flags       BIT(8)       NOT NULL DEFAULT b'00000000',
+  single_bit  BIT(1)       NOT NULL DEFAULT b'0',
+  created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO bit_defaults (flags, single_bit) VALUES
+  (b'10000001', b'1'),
+  (b'00000000', b'0');
+
+-- #1645: CHECK constraints.
+-- MySQL 8.0.16+ enforces these and exposes them in information_schema.CHECK_CONSTRAINTS
+-- with backtick-quoted identifiers.  MariaDB 10.2+ stores them but surfaces them
+-- differently — pgloader reads an empty result from information_schema on MariaDB,
+-- so the expected output for this test differs between the two (see
+-- expected/04-check-constraints.mariadb.out).
+CREATE TABLE salary_check (
+  id         INT AUTO_INCREMENT PRIMARY KEY,
+  name       VARCHAR(100) NOT NULL,
+  salary     DECIMAL(10,2) NOT NULL,
+  age        INT NOT NULL,
+  CONSTRAINT chk_salary_positive CHECK (salary > 0),
+  CONSTRAINT chk_age_range       CHECK (age BETWEEN 18 AND 99)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO salary_check (name, salary, age) VALUES
+  ('Alice', 75000.00, 30),
+  ('Bob',   52000.50, 45);
+
+-- #1560/#1196: ON UPDATE CURRENT_TIMESTAMP → PostgreSQL BEFORE UPDATE trigger
+CREATE TABLE on_update_ts (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  payload     VARCHAR(200),
+  created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO on_update_ts (payload) VALUES ('first'), ('second');
+
+-- #1066: hex-to-bytea cast function
+CREATE TABLE hex_binary (
+  id      INT AUTO_INCREMENT PRIMARY KEY,
+  label   VARCHAR(50),
+  raw_hex VARCHAR(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO hex_binary (label, raw_hex) VALUES
+  ('plain',    'DEADBEEF'),
+  ('prefixed', '0xCAFEBABE'),
+  ('empty',    '');
+
+-- #1522: WITHOUT TYPE cast syntax
+-- perms uses WITHOUT TYPE so the SET type is preserved as an enum array
+-- and values are routed through set-to-enum-array.
+CREATE TABLE set_column (
+  id      INT AUTO_INCREMENT PRIMARY KEY,
+  perms   SET('read','write','execute') NOT NULL DEFAULT 'read'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO set_column (perms) VALUES ('read'), ('read,write'), ('read,write,execute');
+
+GRANT SELECT ON pgloader_mysql_unit_full.* TO 'pgloader'@'%';
+FLUSH PRIVILEGES;

--- a/clojure/tests/mysql-unit-full/sql/01-tables.sql
+++ b/clojure/tests/mysql-unit-full/sql/01-tables.sql
@@ -1,0 +1,6 @@
+-- All tables landed in the v4 schema
+SELECT table_name
+FROM   information_schema.tables
+WHERE  table_schema = 'mysql_unit_full'
+  AND  table_type   = 'BASE TABLE'
+ORDER  BY table_name;

--- a/clojure/tests/mysql-unit-full/sql/02-datetime-precision.sql
+++ b/clojure/tests/mysql-unit-full/sql/02-datetime-precision.sql
@@ -1,0 +1,10 @@
+-- #1629: datetime(N) precision preserved as timestamptz(N) / time(N)
+-- #1403: CURRENT_TIMESTAMP(6) default becomes current_timestamp (keyword, no parens)
+SELECT column_name,
+       data_type,
+       datetime_precision,
+       column_default
+FROM   information_schema.columns
+WHERE  table_schema = 'mysql_unit_full'
+  AND  table_name   = 'type_precision'
+ORDER  BY ordinal_position;

--- a/clojure/tests/mysql-unit-full/sql/03-bit-defaults.sql
+++ b/clojure/tests/mysql-unit-full/sql/03-bit-defaults.sql
@@ -1,0 +1,9 @@
+-- #1280: bit(N) DEFAULT b'0' passes through; column_default is a bit literal
+-- #1403: CURRENT_TIMESTAMP default becomes the keyword (not a quoted string)
+SELECT column_name,
+       data_type,
+       column_default
+FROM   information_schema.columns
+WHERE  table_schema = 'mysql_unit_full'
+  AND  table_name   = 'bit_defaults'
+ORDER  BY ordinal_position;

--- a/clojure/tests/mysql-unit-full/sql/04-check-constraints.sql
+++ b/clojure/tests/mysql-unit-full/sql/04-check-constraints.sql
@@ -1,0 +1,11 @@
+-- #1645: CHECK constraints migrated via ALTER TABLE ADD CONSTRAINT … CHECK (…)
+-- Use pg_constraint (more reliable than information_schema for non-superusers).
+SELECT c.conname AS constraint_name,
+       pg_get_constraintdef(c.oid) AS check_clause
+FROM   pg_constraint c
+JOIN   pg_class t   ON t.oid = c.conrelid
+JOIN   pg_namespace n ON n.oid = t.relnamespace
+WHERE  n.nspname  = 'mysql_unit_full'
+  AND  t.relname  = 'salary_check'
+  AND  c.contype  = 'c'
+ORDER  BY c.conname;

--- a/clojure/tests/mysql-unit-full/sql/05-on-update-trigger.sql
+++ b/clojure/tests/mysql-unit-full/sql/05-on-update-trigger.sql
@@ -1,0 +1,8 @@
+-- #1560/#1196: ON UPDATE CURRENT_TIMESTAMP produces a BEFORE UPDATE trigger
+SELECT trigger_name,
+       event_manipulation,
+       action_timing
+FROM   information_schema.triggers
+WHERE  trigger_schema = 'mysql_unit_full'
+  AND  event_object_table = 'on_update_ts'
+ORDER  BY trigger_name;

--- a/clojure/tests/mysql-unit-full/sql/06-hex-to-bytea.sql
+++ b/clojure/tests/mysql-unit-full/sql/06-hex-to-bytea.sql
@@ -1,0 +1,5 @@
+-- #1066: hex-to-bytea cast — raw_hex column stored as PostgreSQL bytea \x…
+SELECT label,
+       raw_hex
+FROM   mysql_unit_full.hex_binary
+ORDER  BY id;

--- a/clojure/tests/mysql-unit-full/sql/07-without-type.sql
+++ b/clojure/tests/mysql-unit-full/sql/07-without-type.sql
@@ -1,0 +1,11 @@
+-- #1522: WITHOUT TYPE cast — perms column keeps its pgloader-mapped type
+-- (SET → text[]) while set-to-enum-array is applied to convert the value.
+SELECT column_name, data_type, udt_name
+FROM   information_schema.columns
+WHERE  table_schema = 'mysql_unit_full'
+  AND  table_name   = 'set_column'
+ORDER  BY ordinal_position;
+
+SELECT id, perms
+FROM   mysql_unit_full.set_column
+ORDER  BY id;

--- a/clojure/tests/mysql/Dockerfile
+++ b/clojure/tests/mysql/Dockerfile
@@ -25,6 +25,9 @@ COPY test/mysql/db789.sql    /docker-entrypoint-initdb.d/db789.sql
 # === pgloader integration test seed (source + source2 databases) ===
 COPY clojure/tests/mysql/data/seed.sql /docker-entrypoint-initdb.d/seed.sql
 
+# === pgloader v4-only test schema (pgloader_v4 database) ===
+COPY clojure/tests/mysql/data/v4only.sql /docker-entrypoint-initdb.d/v4only.sql
+
 # === Init script ===
 # .sql files renamed to .tmpl to prevent MySQL auto-running them.
 # Our shell script creates the correct databases first, then sources the .tmpl files.
@@ -37,4 +40,5 @@ RUN chmod +x /docker-entrypoint-initdb.d/load-datasets.sh \
   && mv /docker-entrypoint-initdb.d/my.sql        /docker-entrypoint-initdb.d/my.tmpl \
   && mv /docker-entrypoint-initdb.d/history.sql   /docker-entrypoint-initdb.d/history.tmpl \
   && mv /docker-entrypoint-initdb.d/db789.sql     /docker-entrypoint-initdb.d/db789.tmpl \
-  && mv /docker-entrypoint-initdb.d/seed.sql      /docker-entrypoint-initdb.d/seed.tmpl
+  && mv /docker-entrypoint-initdb.d/seed.sql      /docker-entrypoint-initdb.d/seed.tmpl \
+  && mv /docker-entrypoint-initdb.d/v4only.sql   /docker-entrypoint-initdb.d/v4only.tmpl

--- a/clojure/tests/mysql/Dockerfile
+++ b/clojure/tests/mysql/Dockerfile
@@ -25,8 +25,8 @@ COPY test/mysql/db789.sql    /docker-entrypoint-initdb.d/db789.sql
 # === pgloader integration test seed (source + source2 databases) ===
 COPY clojure/tests/mysql/data/seed.sql /docker-entrypoint-initdb.d/seed.sql
 
-# === pgloader v4-only test schema (pgloader_v4 database) ===
-COPY clojure/tests/mysql/data/v4only.sql /docker-entrypoint-initdb.d/v4only.sql
+# === mysql-unit-full test schema (pgloader_mysql_unit_full database) ===
+COPY clojure/tests/mysql-unit-full/mysql-unit-full.sql /docker-entrypoint-initdb.d/mysql-unit-full.sql
 
 # === Init script ===
 # .sql files renamed to .tmpl to prevent MySQL auto-running them.
@@ -40,5 +40,5 @@ RUN chmod +x /docker-entrypoint-initdb.d/load-datasets.sh \
   && mv /docker-entrypoint-initdb.d/my.sql        /docker-entrypoint-initdb.d/my.tmpl \
   && mv /docker-entrypoint-initdb.d/history.sql   /docker-entrypoint-initdb.d/history.tmpl \
   && mv /docker-entrypoint-initdb.d/db789.sql     /docker-entrypoint-initdb.d/db789.tmpl \
-  && mv /docker-entrypoint-initdb.d/seed.sql      /docker-entrypoint-initdb.d/seed.tmpl \
-  && mv /docker-entrypoint-initdb.d/v4only.sql   /docker-entrypoint-initdb.d/v4only.tmpl
+  && mv /docker-entrypoint-initdb.d/seed.sql            /docker-entrypoint-initdb.d/seed.tmpl \
+  && mv /docker-entrypoint-initdb.d/mysql-unit-full.sql /docker-entrypoint-initdb.d/mysql-unit-full.tmpl

--- a/clojure/tests/mysql/Makefile
+++ b/clojure/tests/mysql/Makefile
@@ -27,6 +27,8 @@ v4only:
 	java -jar $(JAR) v4only/v4only.load
 	java -jar $(JAR) regress $(REGRESS_FLAGS) v4only
 
+all-v3: my-v3 sakila-v3 f1db-v3 source-v3
+
 %-v3:
 	$(MAKE) $* PGLOADER_CMD="pgloader --client-min-messages notice"
 

--- a/clojure/tests/mysql/Makefile
+++ b/clojure/tests/mysql/Makefile
@@ -2,9 +2,13 @@ JAR          ?= /pgloader.jar
 PGLOADER_CMD ?= java -jar $(JAR)
 REGRESS_FLAGS ?=
 
-.PHONY: all my sakila f1db source
+.PHONY: all my sakila f1db source v4only
 
-all: my sakila f1db source
+# v4only is included in the default all target so it runs alongside the shared
+# suites.  It always uses the v4 JAR directly (not PGLOADER_CMD) so it runs
+# with v4 even when PGLOADER_CMD is overridden to the pgloader v3 binary.
+# This lets v3 CI runs still validate v4-specific behaviours as a bonus check.
+all: my sakila f1db source v4only
 
 my:
 	$(PGLOADER_CMD) my/my.load
@@ -21,6 +25,19 @@ f1db:
 source:
 	$(PGLOADER_CMD) source/source.load
 	java -jar $(JAR) regress $(REGRESS_FLAGS) source
+
+# v4-only tests: always loaded with the v4 JAR regardless of PGLOADER_CMD.
+# These cover features not present in pgloader v3:
+#   #1629  datetime(N) precision preserved  →  timestamptz(N)
+#   #1403  CURRENT_TIMESTAMP(N) default stripped to keyword
+#   #1280  bit literal b'0' default passes through
+#   #1645  CHECK constraints migrated via ALTER TABLE ADD CONSTRAINT
+#   #1560/#1196  ON UPDATE CURRENT_TIMESTAMP → BEFORE UPDATE trigger
+#   #1066  hex-to-bytea cast function
+#   #1522  WITHOUT TYPE cast syntax
+v4only:
+	java -jar $(JAR) v4only/v4only.load
+	java -jar $(JAR) regress $(REGRESS_FLAGS) v4only
 
 %-v3:
 	$(MAKE) $* PGLOADER_CMD="pgloader --client-min-messages notice"

--- a/clojure/tests/mysql/Makefile
+++ b/clojure/tests/mysql/Makefile
@@ -4,10 +4,6 @@ REGRESS_FLAGS ?=
 
 .PHONY: all my sakila f1db source v4only
 
-# v4only is included in the default all target so it runs alongside the shared
-# suites.  It always uses the v4 JAR directly (not PGLOADER_CMD) so it runs
-# with v4 even when PGLOADER_CMD is overridden to the pgloader v3 binary.
-# This lets v3 CI runs still validate v4-specific behaviours as a bonus check.
 all: my sakila f1db source v4only
 
 my:
@@ -26,15 +22,7 @@ source:
 	$(PGLOADER_CMD) source/source.load
 	java -jar $(JAR) regress $(REGRESS_FLAGS) source
 
-# v4-only tests: always loaded with the v4 JAR regardless of PGLOADER_CMD.
-# These cover features not present in pgloader v3:
-#   #1629  datetime(N) precision preserved  →  timestamptz(N)
-#   #1403  CURRENT_TIMESTAMP(N) default stripped to keyword
-#   #1280  bit literal b'0' default passes through
-#   #1645  CHECK constraints migrated via ALTER TABLE ADD CONSTRAINT
-#   #1560/#1196  ON UPDATE CURRENT_TIMESTAMP → BEFORE UPDATE trigger
-#   #1066  hex-to-bytea cast function
-#   #1522  WITHOUT TYPE cast syntax
+# v4-only tests always use the v4 JAR directly, never $(PGLOADER_CMD).
 v4only:
 	java -jar $(JAR) v4only/v4only.load
 	java -jar $(JAR) regress $(REGRESS_FLAGS) v4only

--- a/clojure/tests/mysql/Makefile
+++ b/clojure/tests/mysql/Makefile
@@ -2,9 +2,9 @@ JAR          ?= /pgloader.jar
 PGLOADER_CMD ?= java -jar $(JAR)
 REGRESS_FLAGS ?=
 
-.PHONY: all my sakila f1db source v4only
+.PHONY: all my sakila f1db source mysql-unit-full
 
-all: my sakila f1db source v4only
+all: my sakila f1db source mysql-unit-full
 
 my:
 	$(PGLOADER_CMD) my/my.load
@@ -22,12 +22,17 @@ source:
 	$(PGLOADER_CMD) source/source.load
 	java -jar $(JAR) regress $(REGRESS_FLAGS) source
 
-# v4-only tests always use the v4 JAR directly, never $(PGLOADER_CMD).
-v4only:
-	java -jar $(JAR) v4only/v4only.load
-	java -jar $(JAR) regress $(REGRESS_FLAGS) v4only
+# mysql-unit-full: full v4 regression suite, always run with the v4 JAR.
+# Never uses $(PGLOADER_CMD) so it runs with v4 even in mixed environments.
+mysql-unit-full:
+	java -jar $(JAR) mysql-unit-full/mysql-unit-full.load
+	java -jar $(JAR) regress $(REGRESS_FLAGS) mysql-unit-full
 
+# all-v3 explicitly excludes mysql-unit-full: it tests v4-specific behaviour
+# and has no meaningful v3 equivalent.  The @: recipe prevents the %-v3
+# catch-all from appending its own recipe (make all PGLOADER_CMD=pgloader).
 all-v3: my-v3 sakila-v3 f1db-v3 source-v3
+	@:
 
 %-v3:
 	$(MAKE) $* PGLOADER_CMD="pgloader --client-min-messages notice"

--- a/clojure/tests/mysql/data/load-datasets.sh
+++ b/clojure/tests/mysql/data/load-datasets.sh
@@ -25,6 +25,6 @@ echo "=== Loading pgloader integration seed (source, source2) ==="
 mysql -u root -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/seed.tmpl
 echo "Seed loaded successfully"
 
-echo "=== Loading pgloader v4-only test schema (pgloader_v4) ==="
-mysql -u root -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/v4only.tmpl
-echo "V4-only test schema loaded successfully"
+echo "=== Loading mysql-unit-full test schema (pgloader_mysql_unit_full) ==="
+mysql -u root -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/mysql-unit-full.tmpl
+echo "mysql-unit-full test schema loaded successfully"

--- a/clojure/tests/mysql/data/load-datasets.sh
+++ b/clojure/tests/mysql/data/load-datasets.sh
@@ -24,3 +24,7 @@ echo "db789 loaded successfully"
 echo "=== Loading pgloader integration seed (source, source2) ==="
 mysql -u root -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/seed.tmpl
 echo "Seed loaded successfully"
+
+echo "=== Loading pgloader v4-only test schema (pgloader_v4) ==="
+mysql -u root -p"$MYSQL_ROOT_PASSWORD" < /docker-entrypoint-initdb.d/v4only.tmpl
+echo "V4-only test schema loaded successfully"

--- a/clojure/tests/mysql/data/v4only.sql
+++ b/clojure/tests/mysql/data/v4only.sql
@@ -1,0 +1,84 @@
+-- V4-only test schema: features implemented in the Clojure rewrite that
+-- have no equivalent in pgloader v3 or produce different output.
+-- Loaded into the `pgloader_v4` database on MySQL 8.0.
+
+CREATE DATABASE IF NOT EXISTS pgloader_v4;
+USE pgloader_v4;
+
+-- #1629: datetime/timestamp precision modifier preserved (datetime(6) → timestamptz(6))
+-- #1403: CURRENT_TIMESTAMP(6) default stripped to current_timestamp
+CREATE TABLE type_precision (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  ts6         DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  ts3         DATETIME(3)  DEFAULT NULL,
+  t3          TIME(3)      DEFAULT NULL,
+  plain_ts    DATETIME     DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO type_precision (ts3, t3) VALUES
+  ('2024-06-01 12:34:56.123', '01:02:03.456'),
+  ('2024-12-31 23:59:59.999', '23:59:59.999');
+
+-- #1280: bit(N) DEFAULT b'0' passes through as bit literal
+-- #1403: CURRENT_TIMESTAMP default is lowercased keyword (not quoted string)
+CREATE TABLE bit_defaults (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  flags       BIT(8)       NOT NULL DEFAULT b'00000000',
+  single_bit  BIT(1)       NOT NULL DEFAULT b'0',
+  created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO bit_defaults (flags, single_bit) VALUES
+  (b'10000001', b'1'),
+  (b'00000000', b'0');
+
+-- #1645: CHECK constraints (MySQL 8.0.16+)
+CREATE TABLE salary_check (
+  id         INT AUTO_INCREMENT PRIMARY KEY,
+  name       VARCHAR(100) NOT NULL,
+  salary     DECIMAL(10,2) NOT NULL,
+  age        INT NOT NULL,
+  CONSTRAINT chk_salary_positive CHECK (salary > 0),
+  CONSTRAINT chk_age_range       CHECK (age BETWEEN 18 AND 99)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO salary_check (name, salary, age) VALUES
+  ('Alice', 75000.00, 30),
+  ('Bob',   52000.50, 45);
+
+-- #1560/#1196: ON UPDATE CURRENT_TIMESTAMP → PostgreSQL trigger
+CREATE TABLE on_update_ts (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  payload     VARCHAR(200),
+  created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO on_update_ts (payload) VALUES ('first'), ('second');
+
+-- #1066: hex-to-bytea cast function
+-- Store hex strings that should land in PostgreSQL as bytea \x...
+CREATE TABLE hex_binary (
+  id      INT AUTO_INCREMENT PRIMARY KEY,
+  label   VARCHAR(50),
+  raw_hex VARCHAR(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO hex_binary (label, raw_hex) VALUES
+  ('plain',    'DEADBEEF'),
+  ('prefixed', '0xCAFEBABE'),
+  ('empty',    '');
+
+-- #1522: WITHOUT TYPE cast syntax
+-- The `status` column uses WITHOUT TYPE so the pgloader SET type is kept
+-- as text[] in PostgreSQL, applying only the cast function (set-to-enum-array).
+CREATE TABLE set_column (
+  id      INT AUTO_INCREMENT PRIMARY KEY,
+  perms   SET('read','write','execute') NOT NULL DEFAULT 'read'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO set_column (perms) VALUES ('read'), ('read,write'), ('read,write,execute');
+
+-- Grant access to the pgloader user
+GRANT SELECT ON pgloader_v4.* TO 'pgloader'@'%';
+FLUSH PRIVILEGES;

--- a/clojure/tests/mysql/docker-compose.yml
+++ b/clojure/tests/mysql/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       MYSQL_USER: pgloader
       MYSQL_PASSWORD: pgloader
     healthcheck:
-      test: ["CMD-SHELL", "mysql -u root -prootpassword -e 'USE source; SELECT COUNT(*) FROM users' 2>/dev/null && mysql -u root -prootpassword -e 'USE sakila; SELECT COUNT(*) FROM actor' 2>/dev/null && mysql -u root -prootpassword -e 'USE f1db; SELECT COUNT(*) FROM circuits' 2>/dev/null"]
+      test: ["CMD-SHELL", "mysql -u root -prootpassword -e 'USE source; SELECT COUNT(*) FROM users' 2>/dev/null && mysql -u root -prootpassword -e 'USE sakila; SELECT COUNT(*) FROM actor' 2>/dev/null && mysql -u root -prootpassword -e 'USE f1db; SELECT COUNT(*) FROM circuits' 2>/dev/null && mysql -u root -prootpassword -e 'USE pgloader_mysql_unit_full; SELECT COUNT(*) FROM salary_check' 2>/dev/null"]
       interval: 10s
       timeout: 10s
       retries: 30
@@ -34,9 +34,11 @@ services:
       dockerfile: clojure/tests/Dockerfile
     volumes:
       - .:/suite
+      - ../mysql-unit-full:/suite/mysql-unit-full
       - ../../target/pgloader.jar:/pgloader.jar:ro
     environment:
       JAR: /pgloader.jar
+      MYSQL_HOST: mysql
       PGHOST: postgres
       PGPORT: "5432"
       PGDATABASE: target

--- a/clojure/tests/mysql/v4only/expected/01-tables.out
+++ b/clojure/tests/mysql/v4only/expected/01-tables.out
@@ -1,0 +1,10 @@
+   table_name   
+----------------
+ bit_defaults
+ hex_binary
+ on_update_ts
+ salary_check
+ set_column
+ type_precision
+(6 rows)
+

--- a/clojure/tests/mysql/v4only/expected/02-datetime-precision.out
+++ b/clojure/tests/mysql/v4only/expected/02-datetime-precision.out
@@ -1,0 +1,9 @@
+ column_name |        data_type         | datetime_precision |  column_default   
+-------------+--------------------------+--------------------+-------------------
+ id          | integer                  |                    | 
+ ts6         | timestamp with time zone |                  6 | CURRENT_TIMESTAMP
+ ts3         | timestamp with time zone |                  3 | 
+ t3          | time without time zone   |                  3 | 
+ plain_ts    | timestamp with time zone |                  6 | CURRENT_TIMESTAMP
+(5 rows)
+

--- a/clojure/tests/mysql/v4only/expected/03-bit-defaults.out
+++ b/clojure/tests/mysql/v4only/expected/03-bit-defaults.out
@@ -1,0 +1,8 @@
+ column_name |        data_type         |  column_default   
+-------------+--------------------------+-------------------
+ id          | integer                  | 
+ flags       | bit varying              | '0'::"bit"
+ single_bit  | bit varying              | '0'::"bit"
+ created_at  | timestamp with time zone | CURRENT_TIMESTAMP
+(4 rows)
+

--- a/clojure/tests/mysql/v4only/expected/04-check-constraints.out
+++ b/clojure/tests/mysql/v4only/expected/04-check-constraints.out
@@ -1,0 +1,6 @@
+   constraint_name   |             check_clause              
+---------------------+---------------------------------------
+ chk_age_range       | CHECK (((age >= 18) AND (age <= 99)))
+ chk_salary_positive | CHECK ((salary > (0)::numeric))
+(2 rows)
+

--- a/clojure/tests/mysql/v4only/expected/05-on-update-trigger.out
+++ b/clojure/tests/mysql/v4only/expected/05-on-update-trigger.out
@@ -1,0 +1,5 @@
+    trigger_name     | event_manipulation | action_timing 
+---------------------+--------------------+---------------
+ trg_on_update_ts_ts | UPDATE             | BEFORE
+(1 row)
+

--- a/clojure/tests/mysql/v4only/expected/06-hex-to-bytea.out
+++ b/clojure/tests/mysql/v4only/expected/06-hex-to-bytea.out
@@ -1,0 +1,7 @@
+  label   |  raw_hex   
+----------+------------
+ plain    | \xdeadbeef
+ prefixed | \xcafebabe
+ empty    | \x
+(3 rows)
+

--- a/clojure/tests/mysql/v4only/expected/07-without-type.out
+++ b/clojure/tests/mysql/v4only/expected/07-without-type.out
@@ -1,0 +1,13 @@
+ column_name | data_type |     udt_name      
+-------------+-----------+-------------------
+ id          | integer   | int4
+ perms       | ARRAY     | _set_column_perms
+(2 rows)
+
+ id |        perms         
+----+----------------------
+  1 | {read}
+  2 | {read,write}
+  3 | {read,write,execute}
+(3 rows)
+

--- a/clojure/tests/mysql/v4only/sql/01-tables.sql
+++ b/clojure/tests/mysql/v4only/sql/01-tables.sql
@@ -1,0 +1,6 @@
+-- All tables landed in the v4 schema
+SELECT table_name
+FROM   information_schema.tables
+WHERE  table_schema = 'v4'
+  AND  table_type   = 'BASE TABLE'
+ORDER  BY table_name;

--- a/clojure/tests/mysql/v4only/sql/02-datetime-precision.sql
+++ b/clojure/tests/mysql/v4only/sql/02-datetime-precision.sql
@@ -1,0 +1,10 @@
+-- #1629: datetime(N) precision preserved as timestamptz(N) / time(N)
+-- #1403: CURRENT_TIMESTAMP(6) default becomes current_timestamp (keyword, no parens)
+SELECT column_name,
+       data_type,
+       datetime_precision,
+       column_default
+FROM   information_schema.columns
+WHERE  table_schema = 'v4'
+  AND  table_name   = 'type_precision'
+ORDER  BY ordinal_position;

--- a/clojure/tests/mysql/v4only/sql/03-bit-defaults.sql
+++ b/clojure/tests/mysql/v4only/sql/03-bit-defaults.sql
@@ -1,0 +1,9 @@
+-- #1280: bit(N) DEFAULT b'0' passes through; column_default is a bit literal
+-- #1403: CURRENT_TIMESTAMP default becomes the keyword (not a quoted string)
+SELECT column_name,
+       data_type,
+       column_default
+FROM   information_schema.columns
+WHERE  table_schema = 'v4'
+  AND  table_name   = 'bit_defaults'
+ORDER  BY ordinal_position;

--- a/clojure/tests/mysql/v4only/sql/04-check-constraints.sql
+++ b/clojure/tests/mysql/v4only/sql/04-check-constraints.sql
@@ -1,0 +1,11 @@
+-- #1645: CHECK constraints migrated via ALTER TABLE ADD CONSTRAINT … CHECK (…)
+-- Use pg_constraint (more reliable than information_schema for non-superusers).
+SELECT c.conname AS constraint_name,
+       pg_get_constraintdef(c.oid) AS check_clause
+FROM   pg_constraint c
+JOIN   pg_class t   ON t.oid = c.conrelid
+JOIN   pg_namespace n ON n.oid = t.relnamespace
+WHERE  n.nspname  = 'v4'
+  AND  t.relname  = 'salary_check'
+  AND  c.contype  = 'c'
+ORDER  BY c.conname;

--- a/clojure/tests/mysql/v4only/sql/05-on-update-trigger.sql
+++ b/clojure/tests/mysql/v4only/sql/05-on-update-trigger.sql
@@ -1,0 +1,8 @@
+-- #1560/#1196: ON UPDATE CURRENT_TIMESTAMP produces a BEFORE UPDATE trigger
+SELECT trigger_name,
+       event_manipulation,
+       action_timing
+FROM   information_schema.triggers
+WHERE  trigger_schema = 'v4'
+  AND  event_object_table = 'on_update_ts'
+ORDER  BY trigger_name;

--- a/clojure/tests/mysql/v4only/sql/06-hex-to-bytea.sql
+++ b/clojure/tests/mysql/v4only/sql/06-hex-to-bytea.sql
@@ -1,0 +1,5 @@
+-- #1066: hex-to-bytea cast — raw_hex column stored as PostgreSQL bytea \x…
+SELECT label,
+       raw_hex
+FROM   v4.hex_binary
+ORDER  BY id;

--- a/clojure/tests/mysql/v4only/sql/07-without-type.sql
+++ b/clojure/tests/mysql/v4only/sql/07-without-type.sql
@@ -1,0 +1,11 @@
+-- #1522: WITHOUT TYPE cast — perms column keeps its pgloader-mapped type
+-- (SET → text[]) while set-to-enum-array is applied to convert the value.
+SELECT column_name, data_type, udt_name
+FROM   information_schema.columns
+WHERE  table_schema = 'v4'
+  AND  table_name   = 'set_column'
+ORDER  BY ordinal_position;
+
+SELECT id, perms
+FROM   v4.set_column
+ORDER  BY id;

--- a/clojure/tests/mysql/v4only/v4only.load
+++ b/clojure/tests/mysql/v4only/v4only.load
@@ -1,0 +1,31 @@
+-- v4-only integration tests: features specific to the Clojure/JVM rewrite.
+-- This load file exercises behaviours not present in pgloader v3:
+--   #1629  datetime(N) precision preserved → timestamptz(N)
+--   #1403  CURRENT_TIMESTAMP(N) default stripped to keyword
+--   #1280  bit literal b'0' default passes through
+--   #1645  CHECK constraints migrated via ALTER TABLE
+--   #1560/#1196  ON UPDATE CURRENT_TIMESTAMP → trigger
+--   #1066  hex-to-bytea cast function
+--   #1522  WITHOUT TYPE cast syntax
+
+load database
+     from      mysql://root:rootpassword@mysql:3306/pgloader_v4?useSSL=false
+     into postgresql://pgloader:pgloader@postgres:5432/target
+
+ WITH create tables,
+      create indexes,
+      include drop,
+      quote identifiers
+
+ ALTER SCHEMA 'pgloader_v4' RENAME TO 'v4'
+
+ CAST
+      -- #1066 hex-to-bytea: load raw_hex column as PostgreSQL bytea
+      column hex_binary.raw_hex to bytea using hex-to-bytea,
+
+      -- #1522 WITHOUT TYPE: preserve the SET→text[] mapping but strip
+      -- the surrounding braces from the comma-separated value
+      column set_column.perms WITHOUT TYPE using set-to-enum-array
+
+ BEFORE LOAD DO
+   $$ CREATE SCHEMA IF NOT EXISTS v4; $$;


### PR DESCRIPTION
Fix a broad set of MySQL-to-PostgreSQL type mapping, default-value handling, constraint migration, cast grammar, and value-conversion issues that were reported across multiple tickets.

## Changes

### `ddl/common.clj`
- Preserve precision modifier on `DATETIME`/`TIMESTAMP`/`TIME` so `datetime(6)` maps to `timestamptz(6)` instead of losing the typemod (#1629)
- Pass PostgreSQL array types (`varchar[]`) through unchanged when used as a source type (#1371)
- Pass bit literals `b'0'`/`b'1'` through as-is in `format-default` (#1280)
- Strip precision from `CURRENT_TIMESTAMP(6)` and similar SQL-keyword defaults before quoting (#1403)
- Escape backslashes in string default values (#1546)
- New `create-check-constraints-sql` function: generates `ALTER TABLE … ADD CONSTRAINT … CHECK (…)` DDL (#1645)

### `source/mysql.sql`
- New `table-checks` query fetches `CHECK` constraints from `information_schema` (returns empty on MySQL < 8.0.16, safe for older servers) (#1645)

### `source/mysql.clj`
- New `text-col-type?` helper; `convert-mysql-value` now calls `getBytes()` on text columns so embedded NUL bytes survive JDBC's `getObject()` truncation (#1573)
- Catalog builder fetches CHECK constraints per table and stores them as `:checks` in the table map (#1645)

### `core.clj`
- Post-load phase: create CHECK constraints after foreign keys (#1645)
- ON UPDATE CURRENT_TIMESTAMP handled via existing trigger DDL path (#1560, #1196)

### `cast.clj`
- New `hex-to-bytea` cast function: converts plain / `0x`-prefixed / `\x`-prefixed hex strings to PostgreSQL `\x…` bytea format (#1066)
- `apply-type-overrides`: rules with `:without-type true` match the column but do not override its type — only the cast function is applied (#1522)

### `load_file/grammar.clj`
- Extend `column-cast` with `CAST column COL WITHOUT TYPE [using fn] [options]*` alternative (#1522)

### `load_file/ast.clj`
- Fix latent bug: unwrap `:cast-option` wrappers before extracting `using-fn` and `drop-*` options; previously the `[:cast-option […]]` layer caused `using` and all drop options to be silently lost when cast rules were read from a load file
- Detect `without-type?` node; set `:without-type true` on the rule map (#1522)

## Already handled (no code change needed)
- ENUM type name uses the post-rename table name because `add-enum-types` runs after `apply-alter-table` (#1564)
- `char(N)` cast rules already use `starts-with` matching (#1525)
- `int-to-uuid` already registered (#1457)
- Quoted multi-word target types already handled by `dq-string` grammar (#1273)
- `multipolygon` already mapped in `pg-type-for` (#625)

## Testing
135 tests, 455 assertions, 0 failures. All new behaviours covered by unit tests in `cast_test.clj`, `ddl_test.clj`, and `load_file/parser_test.clj`.

Closes #1280
Closes #1645
Closes #1560
Closes #1196
Closes #1629
Closes #1403
Closes #1546
Closes #1573
Closes #1066
Closes #625
Closes #1564
Closes #1522
Closes #1525
Closes #1457
Closes #1470
Closes #1273
Closes #1371