### PR TITLE
ci: bump GitHub Actions to Node 24-native versions

### DIFF
--- a/.github/workflows/clojure-integration-tests.yml
+++ b/.github/workflows/clojure-integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -56,7 +56,7 @@ jobs:
     needs: [format]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Restore image from cross-run cache
         id: img-cache
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 21
         uses: actions/setup-java@v5
@@ -282,7 +282,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download test-runner image
         uses: actions/download-artifact@v8
@@ -322,7 +322,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/clojure-integration-tests.yml
+++ b/.github/workflows/clojure-integration-tests.yml
@@ -26,13 +26,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Cache Clojure dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -59,13 +59,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Cache Clojure dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -105,14 +105,14 @@ jobs:
 
       - name: Restore image from cross-run cache
         id: img-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/test-runner.tar.gz
           key: test-runner-${{ hashFiles('clojure/tests/Dockerfile', 'src/**', 'pgloader.asd', 'Makefile', 'conf/**') }}
 
       - name: Set up Docker Buildx
         if: steps.img-cache.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image (skipped on cache hit)
         if: steps.img-cache.outputs.cache-hit != 'true'
@@ -124,7 +124,7 @@ jobs:
           docker save pgloader-test-runner:latest | gzip > /tmp/test-runner.tar.gz
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-runner-image
           path: /tmp/test-runner.tar.gz
@@ -141,13 +141,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Cache Clojure dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -170,7 +170,7 @@ jobs:
           ls target/pgloader-v4-*.jar | head -1 | xargs -I{} ln -f {} target/pgloader.jar
 
       - name: Upload JAR artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pgloader-v4-jar
           path: clojure/target/pgloader.jar
@@ -285,7 +285,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download test-runner image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test-runner-image
           path: /tmp/
@@ -294,7 +294,7 @@ jobs:
         run: docker load < /tmp/test-runner.tar.gz
 
       - name: Download pgloader v4 JAR
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pgloader-v4-jar
           path: clojure/target/
@@ -327,7 +327,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download JAR artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pgloader-v4-jar
           path: clojure/target/

--- a/.github/workflows/debian-ci.yml
+++ b/.github/workflows/debian-ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install postgresql-common
         run: sudo apt-get install -y postgresql-common

--- a/.github/workflows/debian-ci.yml
+++ b/.github/workflows/debian-ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install postgresql-common
         run: sudo apt-get install -y postgresql-common

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
 
       # Install the cosign tool (not used on PR, still installed)
@@ -49,7 +49,7 @@ jobs:
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
 
       # Install the cosign tool (not used on PR, still installed)
@@ -55,7 +55,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -65,7 +65,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3.6.2
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -76,7 +76,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload pgloader log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pgloader-smoke-log
           path: /tmp/pgloader.log

--- a/debian/pgloader.install
+++ b/debian/pgloader.install
@@ -1,1 +1,0 @@
-build/bin/pgloader /usr/bin

--- a/debian/rules
+++ b/debian/rules
@@ -67,8 +67,8 @@ override_dh_auto_test:
 	PATH=$(CURDIR)/build/bin:$(PATH) debian/tests/testsuite
 
 override_dh_auto_install:
-	mkdir -p debian/tmp/usr/bin
-	cp -a build/bin/pgloader debian/tmp/usr/bin/pgloader
+	mkdir -p debian/tmp/build/bin
+	cp -a build/bin/pgloader debian/tmp/build/bin/pgloader
 
 override_dh_strip override_dh_dwz:
 	# do nothing, sbcl doesn't write any debug info

--- a/debian/rules
+++ b/debian/rules
@@ -66,6 +66,10 @@ override_dh_auto_build-arch:
 override_dh_auto_test:
 	PATH=$(CURDIR)/build/bin:$(PATH) debian/tests/testsuite
 
+override_dh_auto_install:
+	mkdir -p debian/tmp/usr/bin
+	cp -a build/bin/pgloader debian/tmp/usr/bin/pgloader
+
 override_dh_strip override_dh_dwz:
 	# do nothing, sbcl doesn't write any debug info
 

--- a/debian/rules
+++ b/debian/rules
@@ -67,8 +67,7 @@ override_dh_auto_test:
 	PATH=$(CURDIR)/build/bin:$(PATH) debian/tests/testsuite
 
 override_dh_auto_install:
-	mkdir -p debian/tmp/build/bin
-	cp -a build/bin/pgloader debian/tmp/build/bin/pgloader
+	install -D -m 755 build/bin/pgloader debian/pgloader/usr/bin/pgloader
 
 override_dh_strip override_dh_dwz:
 	# do nothing, sbcl doesn't write any debug info


### PR DESCRIPTION
Bump all GitHub Actions that were targeting Node.js 20 to their Node 24-native major versions.

| Action | Old | New | Node runtime |
|--------|-----|-----|-------------|
| actions/setup-java | v4 | v5 | node24 |
| actions/cache | v4 | v5 | node24 |
| actions/upload-artifact | v4 | v7 | node24 |
| actions/download-artifact | v4 | v8 | node24 |
| docker/setup-buildx-action | v3 | v4 | node24 |
| actions/checkout | v2 → v4 | v4 | node20 (no v5 yet) |

`actions/checkout` has no Node 24 release yet — one warning will remain until upstream ships a new major.