### PR TITLE
ci: rename master → main + v4-dev release cleanup

### DIFF
--- a/.github/workflows/clojure-integration-tests.yml
+++ b/.github/workflows/clojure-integration-tests.yml
@@ -6,7 +6,7 @@ on:
       - 'clojure/**'
       - '.github/workflows/clojure-integration-tests.yml'
   push:
-    branches: [master, main, citus-v3, v4-clojure-rewrite]
+    branches: [main, citus-v3, v4-clojure-rewrite]
     paths:
       - 'clojure/**'
       - '.github/workflows/clojure-integration-tests.yml'
@@ -340,6 +340,16 @@ jobs:
           cp clojure/target/pgloader.jar "clojure/target/pgloader-${VERSION}.jar"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "sha=${SHA}"         >> "$GITHUB_OUTPUT"
+
+      - name: Delete previous versioned JAR assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view v4-dev --repo ${{ github.repository }} --json assets \
+            --jq '.assets[].name' 2>/dev/null \
+          | grep -E '^pgloader-[0-9]' \
+          | xargs -r -I{} gh release delete-asset v4-dev {} \
+              --repo ${{ github.repository }} --yes || true
 
       - name: Update v4-dev release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,11 +7,11 @@ name: Docker
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ $(BUNDLE): $(BUNDLEDIR) $(BUNDLEDIR)/version.sexp
 	cp bundle/README.md $(BUNDLEDIR)
 	cp bundle/save.lisp $(BUNDLEDIR)
 	sed -e s/%VERSION%/$(VERSION)/ < bundle/Makefile > $(BUNDLEDIR)/Makefile
-	git archive --format=tar --prefix=pgloader-$(VERSION)/ master \
+	git archive --format=tar --prefix=pgloader-$(VERSION)/ main \
 	     | tar -C $(BUNDLEDIR)/local-projects/ -xf -
 	make QLDIR=$(BUNDLEDIR) clones
 	tar -C build/bundle 		    \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ On the fly data transformation
     some tweaking and clean-up before being sent to PostgreSQL.
 
     For instance in the `geolite
-    <https://github.com/dimitri/pgloader/blob/master/test/archive.load>`_
+    <https://github.com/dimitri/pgloader/blob/main/test/archive.load>`_
     example we can see that integer values are being rewritten as IP address
     ranges, allowing to target an ``ip4r`` column directly.
 

--- a/docs/ref/pgsql-citus-target.rst
+++ b/docs/ref/pgsql-citus-target.rst
@@ -79,7 +79,7 @@ to the tables that have a direct or indirect foreign key reference to the
 
 We run pgloader using the following command, where the file
 `./test/citus/company.load
-<https://github.com/dimitri/pgloader/blob/master/test/citus/company.load>`_
+<https://github.com/dimitri/pgloader/blob/main/test/citus/company.load>`_
 contains the pgloader command as shown above.
 
 ::


### PR DESCRIPTION
Follow-up to the branch rename done in the GitHub UI.

## Changes

**Branch rename fixups** — replace all `master` references that would break after the rename:
- `clojure-integration-tests.yml`: drop `master` from push branch filter (already had `main`)
- `docker-publish.yml`: update both push and pull_request branch filters to `main` (was the only workflow that would silently stop triggering)
- `Makefile`: `git archive` target branch for the `bundle` target
- `docs/index.rst`, `docs/ref/pgsql-citus-target.rst`: two `/blob/master/` URLs into this repo

**v4-dev release cleanup** — adds a step to `publish-dev` that deletes old versioned `pgloader-4.x.x-<sha>.jar` assets before uploading the new one. The stable `pgloader.jar` URL is untouched.