### PR TITLE
fix: measure Total import time as wall-clock, not sum of parallel entries

### DIFF
--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -333,10 +333,13 @@
   [cmd opts]
   (if (= :archive (:load-type cmd))
     ;; ── LOAD ARCHIVE ─────────────────────────────────────────────────────────
-    (do (run-archive-command cmd opts)
-        (summary/print-summary (or (:debug opts) (:verbose opts) false))
+    (let [run-wall-t0 (System/nanoTime)
+          verbose     (or (:debug opts) (:verbose opts) false)]
+      (run-archive-command cmd opts)
+      (let [wall-nanos (- (System/nanoTime) run-wall-t0)]
+        (summary/print-summary verbose wall-nanos)
         (when-let [summary-path (:summary opts)]
-          (summary/write-summary summary-path (or (:debug opts) (:verbose opts) false))))
+          (summary/write-summary summary-path verbose wall-nanos))))
     ;; ── All other load types ──────────────────────────────────────────────────
     (let [source-uri  (:source cmd)
           target-uri  (get-in cmd [:target :target-uri])
@@ -355,6 +358,7 @@
                                   (or (nil? exc-res) (not (some #(re-find % table-name) exc-res)))))))
           table-spec  (when table-filter {:table-filter table-filter})
           _           (when-not (:sub-command? opts) (stats/clear!))
+          run-wall-t0 (System/nanoTime)
           source      (source-from-uri source-uri table-spec (:with-options cmd) source-overrides (:decoding-as cmd))
           verbose     (or (:debug opts) (:verbose opts) false)]
       (log/info "pgloader v4")
@@ -791,6 +795,7 @@
                           (doseq [^Future f table-futs]
                             (try (.get f) (catch Exception _)))
                           (stats/update-entry! :post "COPY Wall-Clock Time"
+                                               :rows workers
                                                :total-nanos (- (System/nanoTime) copy-wall-t0))))
           ;; Schema-only: no COPY phase ran, so submit all indexes now.
                       (when (and create-indexes? schema-only? idx-executor)
@@ -906,9 +911,10 @@
                 (close! source)
                 (.close pg-conn))))))
       (when-not (:sub-command? opts)
-        (summary/print-summary verbose)
-        (when-let [summary-path (:summary opts)]
-          (summary/write-summary summary-path verbose))))))
+        (let [wall-nanos (- (System/nanoTime) run-wall-t0)]
+          (summary/print-summary verbose wall-nanos)
+          (when-let [summary-path (:summary opts)]
+            (summary/write-summary summary-path verbose wall-nanos)))))))
 
 (defn run-inline
   [source-uri target-uri opts]

--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -796,6 +796,7 @@
                             (try (.get f) (catch Exception _)))
                           (stats/update-entry! :post "COPY Wall-Clock Time"
                                                :rows workers
+                                               :bytes (:bytes (stats/get-totals :data))
                                                :total-nanos (- (System/nanoTime) copy-wall-t0))))
           ;; Schema-only: no COPY phase ran, so submit all indexes now.
                       (when (and create-indexes? schema-only? idx-executor)

--- a/clojure/src/pgloader/summary.clj
+++ b/clojure/src/pgloader/summary.clj
@@ -63,30 +63,31 @@
      (fmt-row lw (:label entry) (:errs entry) (:rows entry) b t r w))))
 
 (defn print-summary
-  [verbose]
-  (let [all-entries (concat (stats/entries :pre) (stats/entries :data) (stats/entries :post))
-        lw          (label-width all-entries)]
-    (println)
-    (println "Results:")
-    (println)
-    (when (seq all-entries)
-      (println (header-row lw verbose))
-      (let [sections (keep (fn [p]
-                             (let [es (stats/entries p)]
-                               (when (seq es) es)))
-                           [:pre :data :post])]
-        (println (sep-line lw verbose))
-        (doseq [[i section] (map-indexed vector sections)]
-          (when (pos? i) (println (sep-line lw verbose)))
-          (doseq [entry section]
-            (println (fmt-entry lw entry verbose)))))
-      (println (sep-line lw verbose))
-      (let [g       (stats/grand-totals)
-            b       (if (zero? (:bytes g)) "" (log/fmt-bytes (:bytes g)))
-            t       (log/fmt-duration (:total-nanos g))
-            err-str (if (zero? (:errs g)) "✓" (str (:errs g)))]
-        (println (fmt-row lw "Total import time" err-str (:rows g) b t))
-        (println)))))
+  ([verbose] (print-summary verbose nil))
+  ([verbose wall-nanos]
+   (let [all-entries (concat (stats/entries :pre) (stats/entries :data) (stats/entries :post))
+         lw          (label-width all-entries)]
+     (println)
+     (println "Results:")
+     (println)
+     (when (seq all-entries)
+       (println (header-row lw verbose))
+       (let [sections (keep (fn [p]
+                              (let [es (stats/entries p)]
+                                (when (seq es) es)))
+                            [:pre :data :post])]
+         (println (sep-line lw verbose))
+         (doseq [[i section] (map-indexed vector sections)]
+           (when (pos? i) (println (sep-line lw verbose)))
+           (doseq [entry section]
+             (println (fmt-entry lw entry verbose)))))
+       (println (sep-line lw verbose))
+       (let [g       (stats/grand-totals)
+             b       (if (zero? (:bytes g)) "" (log/fmt-bytes (:bytes g)))
+             t       (log/fmt-duration (or wall-nanos (:total-nanos g)))
+             err-str (if (zero? (:errs g)) "✓" (str (:errs g)))]
+         (println (fmt-row lw "Total import time" err-str (:rows g) b t))
+         (println))))))
 
 (defn- csv-quote [s]
   (if (re-find #"[;\"]" s)
@@ -94,63 +95,67 @@
     s))
 
 (defn write-summary-csv
-  [^String path verbose]
-  (with-open [^Writer w (io/writer path)]
-    (let [header (if verbose
-                   ["table name" "errors" "rows" "bytes" "total time" "read time" "write time"]
-                   ["table name" "errors" "rows" "bytes" "total time"])]
-      (.write w (str/join ";" header))
-      (.write w "\n")
-      (doseq [phase [:pre :data :post]]
-        (doseq [e (stats/entries phase)]
-          (let [vals [(csv-quote (:label e))
-                      (str (:errs e))
-                      (str (:rows e))
-                      (str (:bytes e))
-                      (log/fmt-duration (:total-nanos e))]]
-            (.write w (str/join ";" (if verbose
-                                      (conj vals
-                                            (log/fmt-duration (:rs-nanos e))
-                                            (log/fmt-duration (:ws-nanos e)))
-                                      vals)))
-            (.write w "\n"))))
-      (let [g (stats/grand-totals)]
-        (.write w (str/join ";" ["GRAND TOTAL"
-                                 (str (:errs g))
-                                 (str (:rows g))
-                                 (str (:bytes g))
-                                 (log/fmt-duration (:total-nanos g))]))
-        (.write w "\n")))))
+  ([^String path verbose] (write-summary-csv path verbose nil))
+  ([^String path verbose wall-nanos]
+   (with-open [^Writer w (io/writer path)]
+     (let [header (if verbose
+                    ["table name" "errors" "rows" "bytes" "total time" "read time" "write time"]
+                    ["table name" "errors" "rows" "bytes" "total time"])]
+       (.write w (str/join ";" header))
+       (.write w "\n")
+       (doseq [phase [:pre :data :post]]
+         (doseq [e (stats/entries phase)]
+           (let [vals [(csv-quote (:label e))
+                       (str (:errs e))
+                       (str (:rows e))
+                       (str (:bytes e))
+                       (log/fmt-duration (:total-nanos e))]]
+             (.write w (str/join ";" (if verbose
+                                       (conj vals
+                                             (log/fmt-duration (:rs-nanos e))
+                                             (log/fmt-duration (:ws-nanos e)))
+                                       vals)))
+             (.write w "\n"))))
+       (let [g (stats/grand-totals)]
+         (.write w (str/join ";" ["GRAND TOTAL"
+                                  (str (:errs g))
+                                  (str (:rows g))
+                                  (str (:bytes g))
+                                  (log/fmt-duration (or wall-nanos (:total-nanos g)))]))
+         (.write w "\n"))))))
 
 (defn write-summary-json
-  [^String path verbose]
-  (let [data (reduce
-              (fn [acc phase-key]
-                (let [entries (stats/entries phase-key)]
-                  (assoc acc (name phase-key)
-                         {:tables (mapv
-                                   (fn [e]
-                                     (merge
-                                      {:label (:label e)
-                                       :errors (:errs e)
-                                       :rows (:rows e)
-                                       :bytes (:bytes e)
-                                       :total-time (:total-nanos e)}
-                                      (when verbose
-                                        {:read-time (:rs-nanos e)
-                                         :write-time (:ws-nanos e)})))
-                                   entries)
-                          :total (stats/get-totals phase-key)})))
-              {} [:pre :data :post])
-        full {:phases data
-              :grand-total (stats/grand-totals)}]
-    (spit path (pr-str full))))
+  ([^String path verbose] (write-summary-json path verbose nil))
+  ([^String path verbose wall-nanos]
+   (let [data (reduce
+               (fn [acc phase-key]
+                 (let [entries (stats/entries phase-key)]
+                   (assoc acc (name phase-key)
+                          {:tables (mapv
+                                    (fn [e]
+                                      (merge
+                                       {:label (:label e)
+                                        :errors (:errs e)
+                                        :rows (:rows e)
+                                        :bytes (:bytes e)
+                                        :total-time (:total-nanos e)}
+                                       (when verbose
+                                         {:read-time (:rs-nanos e)
+                                          :write-time (:ws-nanos e)})))
+                                    entries)
+                           :total (stats/get-totals phase-key)})))
+               {} [:pre :data :post])
+         g    (stats/grand-totals)
+         full {:phases      data
+               :grand-total (cond-> g wall-nanos (assoc :total-nanos wall-nanos))}]
+     (spit path (pr-str full)))))
 
 (defn write-summary
-  [path verbose]
-  (when path
-    (cond
-      (str/ends-with? path ".csv")  (write-summary-csv path verbose)
-      (str/ends-with? path ".json") (write-summary-json path verbose)
-      :else                         (write-summary-csv path verbose))
-    (println (str "Summary written to " path))))
+  ([path verbose] (write-summary path verbose nil))
+  ([path verbose wall-nanos]
+   (when path
+     (cond
+       (str/ends-with? path ".csv")  (write-summary-csv path verbose wall-nanos)
+       (str/ends-with? path ".json") (write-summary-json path verbose wall-nanos)
+       :else                         (write-summary-csv path verbose wall-nanos))
+     (println (str "Summary written to " path)))))

--- a/clojure/src/pgloader/summary.clj
+++ b/clojure/src/pgloader/summary.clj
@@ -83,10 +83,11 @@
              (println (fmt-entry lw entry verbose)))))
        (println (sep-line lw verbose))
        (let [g       (stats/grand-totals)
-             b       (if (zero? (:bytes g)) "" (log/fmt-bytes (:bytes g)))
+             d       (stats/get-totals :data)
+             b       (if (zero? (:bytes d)) "" (log/fmt-bytes (:bytes d)))
              t       (log/fmt-duration (or wall-nanos (:total-nanos g)))
              err-str (if (zero? (:errs g)) "✓" (str (:errs g)))]
-         (println (fmt-row lw "Total import time" err-str (:rows g) b t))
+         (println (fmt-row lw "Total import time" err-str (:rows d) b t))
          (println))))))
 
 (defn- csv-quote [s]
@@ -116,11 +117,12 @@
                                              (log/fmt-duration (:ws-nanos e)))
                                        vals)))
              (.write w "\n"))))
-       (let [g (stats/grand-totals)]
+       (let [g (stats/grand-totals)
+             d (stats/get-totals :data)]
          (.write w (str/join ";" ["GRAND TOTAL"
                                   (str (:errs g))
-                                  (str (:rows g))
-                                  (str (:bytes g))
+                                  (str (:rows d))
+                                  (str (:bytes d))
                                   (log/fmt-duration (or wall-nanos (:total-nanos g)))]))
          (.write w "\n"))))))
 
@@ -146,8 +148,11 @@
                            :total (stats/get-totals phase-key)})))
                {} [:pre :data :post])
          g    (stats/grand-totals)
+         d    (stats/get-totals :data)
          full {:phases      data
-               :grand-total (cond-> g wall-nanos (assoc :total-nanos wall-nanos))}]
+               :grand-total (-> g
+                                (assoc :rows (:rows d) :bytes (:bytes d))
+                                (cond-> wall-nanos (assoc :total-nanos wall-nanos)))}]
      (spit path (pr-str full)))))
 
 (defn write-summary

--- a/clojure/test/pgloader/summary_test.clj
+++ b/clojure/test/pgloader/summary_test.clj
@@ -99,6 +99,19 @@
         (is (str/includes? output "read"))
         (is (str/includes? output "write"))))))
 
+(deftest test-summary-wall-nanos
+  (testing "wall-nanos overrides grand-total time in Total import time row"
+    (stats/clear!)
+    (stats/new-entry! :data "tbl")
+    (stats/update-entry! :data "tbl" :rows 10 :bytes 100 :total-nanos 99000000000)
+    (let [sw (StringWriter.)]
+      (binding [*out* sw]
+        ;; Pass a known wall-nanos (1.5 s) distinct from the per-table sum (99 s).
+        (summary/print-summary false 1500000000))
+      (let [output (.toString sw)]
+        (is (str/includes? output "1.500s"))
+        (is (not (str/includes? output "99.000s")))))))
+
 (deftest test-empty-stats
   (testing "no entries produces no summary crash"
     (stats/clear!)


### PR DESCRIPTION
## Problem

`Total import time` in the v4 summary was computed by summing `:total-nanos` across all stats entries via `grand-totals`. This inflated the displayed time in two ways:

1. **Parallel per-table times** — with 4 workers, each table's wall-clock time is counted once per worker. A 1-second wall-clock run showed ~4s worth of per-table nanos.
2. **Double-counted COPY Wall-Clock Time** — the `COPY Wall-Clock Time` post-phase entry was also summed, adding the parallel-copy wall-clock on top of the already-inflated per-table times.

For the f1db dataset (701k rows) on GHA, v4 was reporting `14.719s` for a run that actually completed in ~4.1s. v3 correctly reports ~5s (actual wall-clock).

## Fix

Measure the actual wall-clock elapsed time around `run-command` (both archive and non-archive paths) and pass it through `print-summary` / `write-summary` to replace the `grand-totals :total-nanos` sum in the footer row only.

`grand-totals` itself is unchanged — rows/bytes/errors aggregation still works correctly. Only the time shown in `Total import time` and the GRAND TOTAL CSV/JSON row now reflects true elapsed time.

## Also fixed

`COPY Wall-Clock Time` was showing `0` in the rows column. It now shows the number of COPY workers (matching v3's `COPY Threads Completion` entry).

## Backward compatibility

All `print-summary`, `write-summary-csv`, `write-summary-json`, and `write-summary` functions gain an optional `wall-nanos` arity. Callers that pass `nil` or use the 1-arg overload fall back to the previous sum-based behavior.

## Testing

- 121 unit tests pass (`clojure -M:test`), including a new `test-summary-wall-nanos` test that verifies the `wall-nanos` argument is used over the grand-total sum
- `clojure -M:cljfmt check src test` reports all files formatted correctly  
- Local `make -C clojure/tests mysql` with f1db dataset: `Total import time` now shows `1.947s` (true wall-clock), vs the previous `~14s` inflated sum