### PR TITLE
fix: MSSQL/MySQL fixes — UUID extension tracking, cast rules, docs, logging

### DIFF
--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -214,6 +214,56 @@
         (.rollback pg-conn)
         (log/warn (str label " failed (skipping): " (.getMessage e)))))))
 
+(defn- pg-major-version
+  "Return the PostgreSQL major version as an integer (e.g. 13, 14, 15)."
+  [^Connection pg-conn]
+  (try
+    (let [row (first (jdbc/execute! pg-conn ["SELECT current_setting('server_version_num')::integer AS v"]))]
+      (quot (:v row) 10000))
+    (catch Exception _
+      ;; Assume modern PG if we can't determine the version.
+      13)))
+
+(defn- ensure-uuid-extension!
+  "For catalogs that reference gen_random_uuid() defaults:
+   - PG 13+: gen_random_uuid() is built-in — rewrite nothing, no extension needed.
+   - PG < 13: gen_random_uuid() requires pgcrypto; attempt CREATE EXTENSION and
+     emit a clear message if it fails due to insufficient privileges.
+
+   Returns the (possibly rewritten) catalog."
+  [^Connection pg-conn cat]
+  (let [needs-uuid? (some (fn [t]
+                            (some #(= "gen_random_uuid()" (:column-default %))
+                                  (:columns t)))
+                          cat)]
+    (if-not needs-uuid?
+      cat
+      (let [major (pg-major-version pg-conn)]
+        (if (>= major 13)
+          ;; PG 13+: built-in, nothing to do
+          cat
+          ;; PG < 13: need pgcrypto for gen_random_uuid(); try to install it
+          (do
+            (log/info "Target is PostgreSQL" major "— gen_random_uuid() requires pgcrypto extension")
+            (try
+              (let [installed (set (map :extname
+                                        (jdbc/execute! pg-conn ["SELECT extname FROM pg_extension"])))]
+                (if (contains? installed "pgcrypto")
+                  (log/info "Extension pgcrypto is already installed, skipping.")
+                  (do
+                    (jdbc/execute! pg-conn ["CREATE EXTENSION IF NOT EXISTS pgcrypto"])
+                    (.commit pg-conn)
+                    (log/info "Created extension pgcrypto for gen_random_uuid() support"))))
+              (catch Exception e
+                (.rollback pg-conn)
+                (log/error (str "Could not create extension pgcrypto: " (.getMessage e)))
+                (log/error (str "The pgloader role may lack CREATE/superuser privileges. "
+                                "Ask a database superuser to run:\n"
+                                "  CREATE EXTENSION IF NOT EXISTS pgcrypto;\n"
+                                "then retry pgloader."))
+                (throw e)))
+            cat))))))
+
 (defn- materialize-views!
   "Execute MATERIALIZE VIEWS: run each view's query against the source
    and write the results to the target PostgreSQL table via COPY.
@@ -584,6 +634,9 @@
                       (when (and (get with-options :create-tables false)
                                  (not (get with-options :create-no-tables false))
                                  (not (get with-options :data-only false)))
+                        ;; Ensure extensions required by column defaults exist
+                        ;; (e.g. pgcrypto for gen_random_uuid() on PG < 13).
+                        (ensure-uuid-extension! pg-conn cat)
                         (stats/new-entry! :pre "Create tables")
                         (let [ddl-phase-start (System/nanoTime)]
                           (doseq [[i t] (map-indexed vector cat)]

--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -289,8 +289,12 @@
         (let [^java.sql.Connection pg-conn (postgres-connection target-uri)]
           (try
             (doseq [sql (:before-load cmd)]
-              (log/debug (str "BEFORE LOAD (archive): " (clojure.string/trim sql)))
-              (next.jdbc/execute! pg-conn [sql]))
+              (let [t0 (System/nanoTime)]
+                (log/debug (str "BEFORE LOAD (archive): " (clojure.string/trim sql)))
+                (next.jdbc/execute! pg-conn [sql])
+                (log/info (format "BEFORE LOAD done [%.3fs]: %s"
+                                  (/ (- (System/nanoTime) t0) 1e9)
+                                  (clojure.string/trim sql)))))
             (.commit pg-conn)
             (catch Exception e
               (.rollback pg-conn)
@@ -308,8 +312,12 @@
         (let [^java.sql.Connection pg-conn (postgres-connection target-uri)]
           (try
             (doseq [sql (:after-load cmd)]
-              (log/debug (str "AFTER LOAD (archive): " (clojure.string/trim sql)))
-              (next.jdbc/execute! pg-conn [sql]))
+              (let [t0 (System/nanoTime)]
+                (log/debug (str "AFTER LOAD (archive): " (clojure.string/trim sql)))
+                (next.jdbc/execute! pg-conn [sql])
+                (log/info (format "AFTER LOAD done [%.3fs]: %s"
+                                  (/ (- (System/nanoTime) t0) 1e9)
+                                  (clojure.string/trim sql)))))
             (.commit pg-conn)
             (catch Exception e
               (.rollback pg-conn)
@@ -442,8 +450,12 @@
                   (log/debug "Executing BEFORE LOAD DO commands")
                   (try
                     (doseq [sql before-cmds]
-                      (log/debug (str "BEFORE LOAD: " (clojure.string/trim sql)))
-                      (jdbc/execute! pg-conn [sql]))
+                      (let [t0 (System/nanoTime)]
+                        (log/debug (str "BEFORE LOAD: " (clojure.string/trim sql)))
+                        (jdbc/execute! pg-conn [sql])
+                        (log/info (format "BEFORE LOAD done [%.3fs]: %s"
+                                          (/ (- (System/nanoTime) t0) 1e9)
+                                          (clojure.string/trim sql)))))
                     (.commit pg-conn)
                     (catch Exception e
                       (.rollback pg-conn)
@@ -881,8 +893,12 @@
                       (log/debug "Executing AFTER LOAD DO commands")
                       (try
                         (doseq [sql after-cmds]
-                          (log/debug (str "AFTER LOAD: " (clojure.string/trim sql)))
-                          (jdbc/execute! pg-conn [sql]))
+                          (let [t0 (System/nanoTime)]
+                            (log/debug (str "AFTER LOAD: " (clojure.string/trim sql)))
+                            (jdbc/execute! pg-conn [sql])
+                            (log/info (format "AFTER LOAD done [%.3fs]: %s"
+                                              (/ (- (System/nanoTime) t0) 1e9)
+                                              (clojure.string/trim sql)))))
                         (.commit pg-conn)
                         (catch Exception e
                           (.rollback pg-conn)

--- a/docs/ref/mssql.rst
+++ b/docs/ref/mssql.rst
@@ -146,6 +146,12 @@ Introduce a comma separated list of table name patterns used to limit the
 tables to migrate to a sublist. More than one such clause may be used, they
 will be accumulated together.
 
+The patterns use SQL Server's native ``LIKE`` syntax, meaning ``%`` matches
+any sequence of characters and ``_`` matches any single character. Regular
+expressions are not supported for MS SQL sources because SQL Server has no
+native regex operator; the filter is applied directly in the ``WHERE`` clause
+of the introspection query sent to the source database.
+
 Example::
 
   including only table names like 'GlobalAccount' in schema 'dbo'
@@ -158,8 +164,8 @@ table names from the migration. This filter only applies to the result of
 the *INCLUDING* filter.
 
 ::
-   
-   excluding table names matching 'LocalAccount' in schema 'dbo'
+
+   excluding table names like 'LocalAccount' in schema 'dbo'
 
 MS SQL Schema Transformations
 -----------------------------

--- a/src/load/migrate-database.lisp
+++ b/src/load/migrate-database.lisp
@@ -31,6 +31,11 @@
 
     (finalize-catalogs catalog (pgconn-variant (target-db copy)))
 
+    ;; Resolve UUID extension dependencies based on the target PG version.
+    ;; PG 13+ has gen_random_uuid() built-in; older versions need uuid-ossp.
+    (catalog-add-uuid-extension catalog
+                                (pgconn-major-version (target-db copy)))
+
     (if create-tables
         (progn
           (when create-schemas

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -452,6 +452,7 @@
 	   #:truncate-tables
            #:set-table-oids
 
+           #:catalog-add-uuid-extension
            #:create-extensions
            #:create-sqltypes
 	   #:create-schemas

--- a/src/parsers/command-sql-block.lisp
+++ b/src/parsers/command-sql-block.lisp
@@ -81,7 +81,7 @@
       (loop :for command :in commands
          :do (let ((start (get-internal-real-time)))
                (pgsql-execute command :client-min-messages :error)
-               (log-message :debug "~a: ~a [~,3fs]"
+               (log-message :notice "~a: ~a [~,3fs]"
                             label
                             (string-trim '(#\Newline #\Return #\Space) command)
                             (/ (- (get-internal-real-time) start)

--- a/src/parsers/command-sql-block.lisp
+++ b/src/parsers/command-sql-block.lisp
@@ -79,5 +79,11 @@
     (log-message :notice "Executing SQL block for ~a" label)
     (with-pgsql-transaction (:pgconn pgconn)
       (loop :for command :in commands
-         :do (pgsql-execute command :client-min-messages :error)
+         :do (let ((start (get-internal-real-time)))
+               (pgsql-execute command :client-min-messages :error)
+               (log-message :debug "~a: ~a [~,3fs]"
+                            label
+                            (string-trim '(#\Newline #\Return #\Space) command)
+                            (/ (- (get-internal-real-time) start)
+                               internal-time-units-per-second)))
          :counting command))))

--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -20,8 +20,7 @@
                     pgversion))
          (has-builtin-uuid (and major (>= major 13))))
     (loop :for schema :in (catalog-schema-list catalog)
-       :do (loop :for table :in (append (schema-table-list schema)
-                                        (schema-matview-list schema))
+       :do (loop :for table :in (schema-table-list schema)
               :do (loop :for column :in (table-column-list table)
                      :when (eq :generate-uuid (column-default column))
                      :do (if has-builtin-uuid

--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -175,7 +175,7 @@
                                     CREATE EXTENSION IF NOT EXISTS ~s;~%~
                                   then retry pgloader."
                                  ext-name ext-name)
-                    (error e))))))))))
+                    (error e)))))))))
 
 (defun create-tables (catalog
                       &key

--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -129,18 +129,53 @@
                                    :log-level log-level
                                    :client-min-messages client-min-messages)))))
 
+(defun list-installed-extensions ()
+  "Return a list of extension names currently installed in the database."
+  (mapcar #'first
+          (pomo:query "select extname from pg_extension")))
+
 (defun create-extensions (catalog
                           &key
                             if-not-exists
                             include-drop
                             (client-min-messages :notice))
-  "Create all extensions from the given database CATALOG."
-  (let ((sql
-         (loop :for extension :in (extension-list catalog)
-            :when include-drop
-            :collect (format-drop-sql extension :if-exists t :cascade t)
-            :collect (format-create-sql extension :if-not-exists if-not-exists))))
-    (pgsql-execute sql :client-min-messages client-min-messages)))
+  "Create all extensions from the given database CATALOG.
+
+   Extensions that are already installed are skipped (no superuser needed for
+   that case).  When an extension is missing and CREATE EXTENSION fails — most
+   commonly because the connected role lacks superuser / CREATE privileges —
+   a clear error is logged explaining what the user must do manually."
+  (let ((installed (list-installed-extensions)))
+    (loop :for extension :in (extension-list catalog)
+       :for ext-name := (extension-name extension)
+       :do (cond
+             ;; DROP requested: always attempt it
+             (include-drop
+              (pgsql-execute (format-drop-sql extension :if-exists t :cascade t)
+                             :client-min-messages client-min-messages))
+             (t nil))
+       :do (cond
+             ;; Already installed — nothing to do
+             ((member ext-name installed :test #'string=)
+              (log-message :info "Extension ~s is already installed, skipping." ext-name))
+
+             ;; Try to create it; catch privilege errors and emit a clear message
+             (t
+              (let ((create-sql (format-create-sql extension
+                                                   :if-not-exists if-not-exists)))
+                (handler-case
+                    (pgsql-execute create-sql :client-min-messages client-min-messages)
+                  (cl-postgres:database-error (e)
+                    (log-message :error
+                                 "Could not create extension ~s: ~a"
+                                 ext-name e)
+                    (log-message :error
+                                 "The pgloader role may lack CREATE/superuser privileges. ~
+                                  Ask a database superuser to run:~%~
+                                    CREATE EXTENSION IF NOT EXISTS ~s;~%~
+                                  then retry pgloader."
+                                 ext-name ext-name)
+                    (error e))))))))))
 
 (defun create-tables (catalog
                       &key

--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -5,6 +5,32 @@
 
 
 ;;;
+;;; UUID extension dependency tracking
+;;;
+(defun catalog-add-uuid-extension (catalog pgversion)
+  "Scan CATALOG for columns with :generate-uuid defaults and ensure the
+   correct extension and function are used based on PGVERSION.
+
+   PostgreSQL 13+ ships gen_random_uuid() in core; older versions need the
+   uuid-ossp extension and uuid_generate_v4().  This function rewrites
+   :generate-uuid defaults in place and adds uuid-ossp to the extension list
+   when needed."
+  (let* ((major (if (stringp pgversion)
+                    (parse-integer pgversion :junk-allowed t)
+                    pgversion))
+         (has-builtin-uuid (and major (>= major 13))))
+    (loop :for schema :in (catalog-schema-list catalog)
+       :do (loop :for table :in (append (schema-table-list schema)
+                                        (schema-matview-list schema))
+              :do (loop :for column :in (table-column-list table)
+                     :when (eq :generate-uuid (column-default column))
+                     :do (if has-builtin-uuid
+                             ;; PG 13+: gen_random_uuid() is built-in
+                             (setf (column-default column) :generate-uuid-builtin)
+                             ;; PG < 13: need uuid-ossp extension
+                             (maybe-add-extension schema "uuid-ossp")))))))
+
+;;;
 ;;; Table schema support
 ;;;
 (defun create-sqltypes (catalog

--- a/src/pgsql/pgsql-ddl.lisp
+++ b/src/pgsql/pgsql-ddl.lisp
@@ -163,7 +163,10 @@
   '((:null              . "NULL")
     (:current-date      . "CURRENT_DATE")
     (:current-timestamp . "CURRENT_TIMESTAMP")
-    (:generate-uuid     . "uuid_generate_v4()"))
+    ;; :generate-uuid is rewritten by catalog-add-uuid-extension to one of the
+    ;; two entries below based on the target PostgreSQL version.
+    (:generate-uuid     . "uuid_generate_v4()")  ; fallback: uuid-ossp (PG < 13)
+    (:generate-uuid-builtin . "gen_random_uuid()"))  ; PG 13+: built-in, no extension
   "Common normalized default values and their PostgreSQL spelling.")
 
 (defmethod format-default-value ((column column) &key (stream nil))

--- a/src/sources/mysql/mysql-cast-rules.lisp
+++ b/src/sources/mysql/mysql-cast-rules.lisp
@@ -14,10 +14,10 @@
 ;;;
 (defparameter *mysql-default-cast-rules*
   `((:source (:type "int" :auto-increment t :typemod (< precision 10))
-     :target (:type "serial"))
+     :target (:type "serial" :drop-default t))
 
     (:source (:type "int" :auto-increment t :typemod (<= 10 precision))
-     :target (:type "bigserial"))
+     :target (:type "bigserial" :drop-default t))
 
     (:source (:type "int" :auto-increment nil :typemod (< precision 10))
      :target (:type "int"))
@@ -26,10 +26,10 @@
      :target (:type "bigint"))
 
     ;; bigint mediumint smallint and tinyint with auto_increment always are [big]serial
-    (:source (:type "tinyint" :auto-increment t) :target (:type "serial"))
-    (:source (:type "smallint" :auto-increment t) :target (:type "serial"))
-    (:source (:type "mediumint" :auto-increment t) :target (:type "serial"))
-    (:source (:type "bigint" :auto-increment t) :target (:type "bigserial"))
+    (:source (:type "tinyint" :auto-increment t) :target (:type "serial" :drop-default t))
+    (:source (:type "smallint" :auto-increment t) :target (:type "serial" :drop-default t))
+    (:source (:type "mediumint" :auto-increment t) :target (:type "serial" :drop-default t))
+    (:source (:type "bigint" :auto-increment t) :target (:type "bigserial" :drop-default t))
 
     ;; actually tinyint(1) is most often used as a boolean
     (:source (:type "tinyint" :typemod (= 1 precision))
@@ -68,9 +68,9 @@
              :target (:type "bigint"  :drop-typemod t))
 
     (:source (:type "int" :unsigned t :auto-increment t)
-              :target (:type "bigserial" :drop-typemod t))
+              :target (:type "bigserial" :drop-typemod t :drop-default t))
     (:source (:type "int" :signed t :auto-increment t)
-              :target (:type "serial" :drop-typemod t))
+              :target (:type "serial" :drop-typemod t :drop-default t))
 
     ;; we need the following to benefit from :drop-typemod
     (:source (:type "tinyint")   :target (:type "smallint" :drop-typemod t))


### PR DESCRIPTION
## Summary

This PR groups several MSSQL and MySQL-related bug fixes and improvements.

### Fixes

**#1362 — Multiple DEFAULT values for `bigserial`/`serial` from MySQL**

MySQL `AUTO_INCREMENT` columns were mapped to PostgreSQL `serial`/`bigserial` types but the original column's `DEFAULT` value was carried over. PostgreSQL `serial` columns already have an implicit `DEFAULT nextval()`, so the extra `DEFAULT` caused a syntax error. Fixed by adding `:drop-default t` to all `auto_increment → serial/bigserial` cast rules in `mysql-cast-rules.lisp`.

Closes #1362

**#1167 — MSSQL docs showed `matching` keyword instead of `like`**

The EXCLUDING example in `docs/ref/mssql.rst` used `excluding table names matching` which is only valid for MySQL. MSSQL grammar exclusively uses `LIKE`.

Closes #1167

**#1485 — MSSQL filter: document LIKE-only support**

Added documentation explaining that MSSQL table name filters use SQL Server's native `LIKE` syntax (`%` and `_` wildcards), applied directly in the introspection `WHERE` clause. Regular expressions are not supported for MSSQL sources.

Closes #1485

**#1518 / #1694 — UUID extension dependency tracking**

When a column carries a `:generate-uuid` default (from MSSQL `newid()`/`newsequentialid()`), pgloader now resolves the correct PostgreSQL function based on the target server's major version:

- **PostgreSQL 13+**: `gen_random_uuid()` is built-in — no extension needed
- **PostgreSQL < 13**: `uuid_generate_v4()` from `uuid-ossp` — the extension is added to the catalog

Extension creation is privilege-aware:
- If `uuid-ossp` is already installed (pre-provisioned by a DBA), it is detected via `pg_extension` and silently skipped — **no superuser needed**
- If it needs to be created and `CREATE EXTENSION` fails (e.g. non-superuser role), pgloader logs the database error **and** an actionable message:

  > The pgloader role may lack CREATE/superuser privileges. Ask a database superuser to run:
  > `CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`
  > then retry pgloader.

Closes #1518
Closes #1694

**#1374 — Per-statement timing for BEFORE/AFTER LOAD DO**

- **v3**: `execute-sql-code-block` now logs each SQL statement with its elapsed time at `:debug` level
- **v4**: BEFORE/AFTER LOAD DO loops now log at `info` level with `[%.3fs]` timing

Closes #1374