### PR TITLE
debian: use $(CURDIR) in help2man PATH to fix intermittent build failure

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -74,7 +74,7 @@ override_dh_strip override_dh_dwz:
 
 override_dh_installman-arch:
 	mkdir -p debian/pgloader/usr/share/man/man1/
-	PATH=debian/pgloader/usr/bin:$(PATH) \
+	PATH=$(CURDIR)/debian/pgloader/usr/bin:$(PATH) \
 	help2man --version-string $(DEB_VERSION_UPSTREAM) \
 		--no-info \
 		--name "extract, transform and load data into PostgreSQL" \


### PR DESCRIPTION
## Problem

`override_dh_installman-arch` locates the staged pgloader binary via a relative PATH:

```makefile
PATH=debian/pgloader/usr/bin:$(PATH) \
```

`dpkg-buildpackage` can shift the working directory during dh sequence execution. When that happens, `debian/pgloader/usr/bin` resolves to nothing, `help2man` cannot exec `pgloader --help`, and exits 127:

```
help2man: can't get `--help' info from pgloader
Try `--no-discard-stderr' if option outputs to stderr
make[1]: *** [debian/rules:77: override_dh_installman-arch] Error 127
```

This is intermittent because push-event and PR-event jobs land on different GitHub-hosted runners with different working-directory state — one run passes while the other fails on the same commit.

## Fix

Replace the relative path with $(CURDIR), which is a make variable that always expands to the build root regardless of working-directory shifts:

```makefile
PATH=$(CURDIR)/debian/pgloader/usr/bin:$(PATH) \
```

This matches the pattern already used two lines above in `override_dh_auto_test`:

```makefile
PATH=$(CURDIR)/build/bin:$(PATH) debian/tests/testsuite
```

## Relation to PR #1711

PR #1711 fixed the first failure mode (binary not staged to `debian/tmp/`, so `dh_install` couldn't find it). This PR fixes the second failure mode (binary is staged but `help2man` can't find it due to relative PATH). Both are needed for a consistently green Debian build.