### PR TITLE
docs: fix duplicate word in MySQL tutorial

### DIFF
--- a/docs/tutorial/mysql.rst
+++ b/docs/tutorial/mysql.rst
@@ -13,7 +13,7 @@ In a Single Command Line
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 As an example, we will use the f1db database from <http://ergast.com/mrd/>
-which which provides a historical record of motor racing data for
+which provides a historical record of motor racing data for
 non-commercial purposes. You can either use their API or download the whole
 database at `http://ergast.com/downloads/f1db.sql.gz
 <http://ergast.com/downloads/f1db.sql.gz>`_. Once you've done that load the


### PR DESCRIPTION
Cherry-pick of #1638 by @igorlealantunes onto current main.

Removes the duplicate word `which` from `docs/tutorial/mysql.rst`.

Closes #1638

Co-authored-by: igorlealantunes <igorlealantunes@gmail.com>