### PR TITLE
docs: mention Amazon Linux 2 in INSTALL.md Redhat/CentOS section

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,7 @@ backporting the one found in `sid` rather than using the very old one found
 in current *stable* debian release. See `bootstrap-debian.sh` for details
 about how to backport a recent enough SBCL here (1.2.5 or newer).
 
-### Redhat / CentOS
+### Redhat / CentOS / Amazon Linux 2
 
 To build and install pgloader the Steel Bank Common Lisp package (sbcl) from EPEL,
 and the freetds packages are required.


### PR DESCRIPTION
Cherry-pick of #1529 by @orangewolf onto current main.

Adds `/ Amazon Linux 2` to the Redhat / CentOS section heading in INSTALL.md — the EPEL/sbcl/freetds instructions apply equally to Amazon Linux 2.

Closes #1529

Co-authored-by: Rob Kaufman <rob@notch8.com>