### PR TITLE
fix(pgsql): restrict pg_depend join to pg_class to fix FK listing on citext columns

### DIFF
--- a/src/pgsql/sql/list-all-fkeys.sql
+++ b/src/pgsql/sql/list-all-fkeys.sql
@@ -29,6 +29,7 @@
         JOIN pg_class cf on r.confrelid = cf.oid
         JOIN pg_namespace nf on cf.relnamespace = nf.oid
         JOIN pg_depend d on d.classid = 'pg_constraint'::regclass
+                        and d.refclassid = 'pg_class'::regclass
                         and d.objid = r.oid
                         and d.refobjsubid = 0
    where r.contype = 'f'


### PR DESCRIPTION
Cherry-pick of #1310 by @MikeN123 onto current main.

When listing foreign keys on a PostgreSQL source, the `pg_depend` join
returned spurious rows for FKs that reference a `citext` column — PostgreSQL
records an additional dependency from the FK constraint to the `citext`
operator in `pg_operator`. Without filtering `refclassid`, that operator row
was returned alongside the correct table row, and the v3 code crashed when it
tried to use a `pg_operator` OID as a table OID:

```
NIL is not of type PGLOADER.CATALOG:INDEX
```

Adding `d.refclassid = 'pg_class'::regclass` restricts the join to only
dependencies whose referenced object is a table — the only valid case for an
FK constraint's primary dependency.

v4 is not affected: its `table-fkeys` query uses `information_schema` views
and never touches `pg_depend`.

Closes #1310
Fixes #1289

Co-authored-by: Mike Noordermeer <mike@eveoh.nl>