### PR TITLE
fix(pgsql): quote index names to preserve case on migration

### DIFF
--- a/src/pgsql/pgsql-ddl.lisp
+++ b/src/pgsql/pgsql-ddl.lisp
@@ -220,7 +220,7 @@
         ;; LOCK on the table before we have the index done already
         (or (index-sql index)
             (format stream
-                    "CREATE UNIQUE INDEX ~a ON ~a (~{~a~^, ~})~@[ WHERE ~a~];"
+                    "CREATE UNIQUE INDEX ~s ON ~a (~{~a~^, ~})~@[ WHERE ~a~];"
                     index-name
                     (format-table-name table)
                     (index-columns index)
@@ -246,7 +246,7 @@
            (multiple-value-bind (access-method expression)
                (index-access-method index)
             (format stream
-                    "CREATE~:[~; UNIQUE~] INDEX ~a ON ~a ~@[USING ~a~](~{~a~^, ~})~@[ WHERE ~a~];"
+                    "CREATE~:[~; UNIQUE~] INDEX ~s ON ~a ~@[USING ~a~](~{~a~^, ~})~@[ WHERE ~a~];"
                     (index-unique index)
                     index-name
                     (format-table-name table)


### PR DESCRIPTION
Fixes a bug where mixed-case index names were silently lowercased on the
target PostgreSQL database because the `CREATE [UNIQUE] INDEX` format strings
used `~a` (unquoted) for the index name.

The fix replaces `~a` with `~s` in both `format-create-sql` paths in
`pgsql-ddl.lisp`. `~s` uses `prin1`, which wraps the string in double quotes,
matching the pattern already used for identifier quoting in
`pgsql-create-schema.lisp` (`CREATE EXTENSION`, `ALTER DATABASE`).

v4 is not affected: `ddl/common.clj` has a dedicated `identifier-quote`
function that correctly handles all index names, including embedded double quotes.

Closes #1521
Fixes #1327