### PR TITLE
fix(mssql): multi-column foreign keys only kept last column

### DIFF
--- a/clojure/tests/mssql/expected/08-pkeys.out
+++ b/clojure/tests/mssql/expected/08-pkeys.out
@@ -1,10 +1,10 @@
  pk_constraints 
 ----------------
-              5
+              7
 (1 row)
 
  total_indexes 
 ---------------
-             7
+             9
 (1 row)
 

--- a/clojure/tests/mssql/expected/11-multi-col-fkeys.out
+++ b/clojure/tests/mssql/expected/11-multi-col-fkeys.out
@@ -1,0 +1,16 @@
+ fk_count 
+----------
+        1
+(1 row)
+
+ column_name | ordinal_position 
+-------------+------------------
+ region_id   |                1
+ product_id  |                2
+(2 rows)
+
+ child_rows 
+------------
+          3
+(1 row)
+

--- a/clojure/tests/mssql/init.sql
+++ b/clojure/tests/mssql/init.sql
@@ -80,6 +80,41 @@ GO
 INSERT INTO default_edge_cases DEFAULT VALUES;
 GO
 
+-- #1594: multi-column foreign key — verify all columns are preserved.
+-- `composite_parent` has a two-column primary key; `composite_child` references
+-- both columns via a single FK constraint.  Before the fix, only the last
+-- column was kept, producing a broken one-column FK.
+CREATE TABLE composite_parent (
+    region_id   INT NOT NULL,
+    product_id  INT NOT NULL,
+    name        NVARCHAR(100),
+    CONSTRAINT pk_composite_parent PRIMARY KEY (region_id, product_id)
+);
+GO
+
+CREATE TABLE composite_child (
+    id          INT IDENTITY(1,1) PRIMARY KEY,
+    region_id   INT NOT NULL,
+    product_id  INT NOT NULL,
+    qty         INT NOT NULL DEFAULT 1,
+    CONSTRAINT fk_child_parent
+        FOREIGN KEY (region_id, product_id)
+        REFERENCES composite_parent(region_id, product_id)
+);
+GO
+
+INSERT INTO composite_parent (region_id, product_id, name) VALUES
+    (1, 10, N'Widget-A'),
+    (1, 20, N'Widget-B'),
+    (2, 10, N'Gadget-A');
+GO
+
+INSERT INTO composite_child (region_id, product_id, qty) VALUES
+    (1, 10, 5),
+    (1, 20, 3),
+    (2, 10, 1);
+GO
+
 -- ============================================================
 -- filtertest: separate database for #1578/#1603 regression.
 --

--- a/clojure/tests/mssql/sql/11-multi-col-fkeys.sql
+++ b/clojure/tests/mssql/sql/11-multi-col-fkeys.sql
@@ -1,0 +1,24 @@
+-- #1594: multi-column FK — verify the constraint was created with BOTH columns.
+-- Before the fix, only the last column survived, producing a broken 1-column FK
+-- that PostgreSQL would accept but that silently mis-mapped column references.
+
+-- Number of FK constraints from composite_child
+SELECT count(*) AS fk_count
+FROM   information_schema.table_constraints
+WHERE  table_schema    = 'public'
+  AND  table_name      = 'composite_child'
+  AND  constraint_type = 'FOREIGN KEY';
+
+-- Columns included in that FK, in ordinal order (must be exactly 2)
+SELECT kcu.column_name, kcu.ordinal_position
+FROM   information_schema.key_column_usage kcu
+JOIN   information_schema.table_constraints tc
+         ON  tc.constraint_name = kcu.constraint_name
+         AND tc.table_schema    = kcu.table_schema
+WHERE  tc.table_schema    = 'public'
+  AND  tc.table_name      = 'composite_child'
+  AND  tc.constraint_type = 'FOREIGN KEY'
+ORDER BY kcu.ordinal_position;
+
+-- Row count survives referential integrity (all 3 child rows are valid)
+SELECT count(*) AS child_rows FROM composite_child;

--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -120,7 +120,7 @@
 
 (defmethod fetch-foreign-keys ((catalog catalog) (mssql copy-mssql)
                                &key including excluding)
-  "Get the list of MSSQL index definitions per table."
+  "Get the list of MSSQL foreign key definitions per table."
   (loop
      :with incl-where := (filter-list-to-where-clause
                           mssql including :not nil
@@ -154,7 +154,8 @@
                             :update-rule fk-update-rule
                             :delete-rule fk-delete-rule))
                 (fkey
-                 (maybe-add-fkey table fkey-name pg-fkey :key #'fkey-name)))
+                 (maybe-add-fkey table (apply-identifier-case fkey-name) pg-fkey
+                                 :key #'fkey-name)))
            (push-to-end col-name (fkey-columns fkey))
            (push-to-end fcol-name (fkey-foreign-columns fkey)))
      :finally (return catalog)))


### PR DESCRIPTION
## Problem

When a SQL Server foreign key spans multiple columns, pgloader v3 only
retained the last column. A two-column FK `(region_id, product_id)` to
`(region_id, product_id)` was created as a one-column FK, silently
breaking the constraint.

## Root cause

`fetch-foreign-keys` issues one row per FK column (the SQL query returns
one row per column, ordered by constraint name then ordinal position). It
calls `maybe-add-fkey` on each row: if the FK already exists it appends
the next column; if not it creates a new one.

The bug was in the lookup key passed to `maybe-add-fkey`. The stored FK
carries the `apply-identifier-case`-transformed name, but the lookup
compared the raw SQL name against it — so `find-fkey` always missed, a
new single-column FK was created on every row, and only the last one
survived.

## Fix

One line: wrap `fkey-name` in `(apply-identifier-case ...)` when passing
the lookup key to `maybe-add-fkey`, so the search key matches what is
actually stored. The docstring (which said "index" instead of "foreign
key") is also corrected.

## Files changed

- **`src/sources/mssql/mssql-schema.lisp`** — the fix (2 lines)
- **`clojure/tests/mssql/init.sql`** — adds `composite_parent` /
  `composite_child` tables with a two-column FK and 3 rows each
- **`clojure/tests/mssql/sql/11-multi-col-fkeys.sql`** — verifies FK
  count, both column names in ordinal order, and child row count
- **`clojure/tests/mssql/expected/11-multi-col-fkeys.out`** — expected
  output for the new test
- **`clojure/tests/mssql/expected/08-pkeys.out`** — updated PK/index
  counts (+2 for the two new tables)

v4 already handles multi-column FKs correctly (it groups rows by
constraint name in Clojure); no v4 source change needed.

## Testing

- `make -C clojure/tests mssql` (v4): all 11 tests pass
- CI `mssql (v3)` and `mssql (v4)`: both pass

Closes #1594.
