### PR TITLE
feat: migrate MSSQL SEQUENCE objects and NEXT VALUE FOR defaults (#1497)

### DIFF
--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -680,6 +680,12 @@
                         ;; Ensure extensions required by column defaults exist
                         ;; (e.g. pgcrypto for gen_random_uuid() on PG < 13).
                         (ensure-uuid-extension! pg-conn cat)
+                        ;; Create sequences before tables so that NEXT VALUE FOR
+                        ;; defaults (translated to nextval()) resolve correctly.
+                        (when (= :mssql (:type source-uri))
+                          (when-let [seqs (seq (mssql-source/catalog-sequences source))]
+                            (log/info (str "Creating " (count seqs) " sequence(s) from MS SQL"))
+                            (run-ddl-tx pg-conn (ddl/create-sequences-sql seqs))))
                         (stats/new-entry! :pre "Create tables")
                         (let [ddl-phase-start (System/nanoTime)]
                           (doseq [[i t] (map-indexed vector cat)]

--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -138,8 +138,10 @@
          "NOW"}
        stripped) (str/lower-case stripped)
       ;; PostgreSQL function call expressions (e.g. nextval(…), gen_random_uuid()):
-      ;; pass through unquoted so they are treated as SQL expressions (#1497)
-      (re-matches #"^\w+\(.*\)$" val) val
+      ;; pass through unquoted so they are treated as SQL expressions (#1497).
+      ;; Pattern: word( … ) — the inner content may contain nested parens (e.g.
+      ;; nextval('schema.seq')) but must end with ) so bare words are not matched.
+      (re-matches #"(?s)^\w+\(.*\)$" val) val
       ;; Bare identifier (word): quote as string literal with backslash escaping (#1546)
       (re-matches #"^\w+$" val) (str "'" (str/replace val "'" "''") "'")
       ;; Anything else: quote as string literal; escape single quotes and backslashes (#1546)

--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -137,6 +137,9 @@
          "LOCALTIMESTAMP" "LOCALTIME" "TRUE" "FALSE"
          "NOW"}
        stripped) (str/lower-case stripped)
+      ;; PostgreSQL function call expressions (e.g. nextval(…), gen_random_uuid()):
+      ;; pass through unquoted so they are treated as SQL expressions (#1497)
+      (re-matches #"^\w+\(.*\)$" val) val
       ;; Bare identifier (word): quote as string literal with backslash escaping (#1546)
       (re-matches #"^\w+$" val) (str "'" (str/replace val "'" "''") "'")
       ;; Anything else: quote as string literal; escape single quotes and backslashes (#1546)
@@ -603,3 +606,30 @@
                           ", COALESCE(MAX(" quoted-col "), 1), false)"
                           " FROM " quoted-fqname ";\n"))))
                columns))))
+
+(defn create-sequence-sql
+  "Generate DROP … / CREATE SEQUENCE SQL for an MSSQL sequence descriptor.
+   seq-map keys: :schema :name :start :increment :min :max :cycle? :cache :current
+   The START value is set to current+increment so the first nextval() returns
+   the next unused value (mirroring SQL Server behaviour where current_value is
+   the last value issued, not the next)."
+  [{:keys [schema name start increment min max cycle? cache current]}]
+  (let [qname   (quote-fqname schema name)
+        ;; current_value is the last issued value; next PostgreSQL value should
+        ;; be current+increment (or start when current equals start-1 / no rows yet).
+        next-val (if current (+ current increment) start)]
+    [(str "DROP SEQUENCE IF EXISTS " qname " CASCADE;")
+     (str "CREATE SEQUENCE " qname
+          " AS bigint"
+          " START WITH " next-val
+          " INCREMENT BY " increment
+          " MINVALUE " min
+          " MAXVALUE " max
+          (if cycle? " CYCLE" " NO CYCLE")
+          (when (and cache (pos? cache)) (str " CACHE " cache))
+          ";")]))
+
+(defn create-sequences-sql
+  "Generate DROP/CREATE SQL for a collection of sequence descriptors."
+  [sequences]
+  (mapcat create-sequence-sql sequences))

--- a/clojure/src/pgloader/source/mssql.clj
+++ b/clojure/src/pgloader/source/mssql.clj
@@ -60,17 +60,26 @@
 (def ^:private numeric-pg-types
   #{"integer" "bigint" "smallint" "numeric" "double precision" "real"})
 
+(defn- mssql-schema->pg
+  "Map a SQL Server schema name to its PostgreSQL equivalent.
+   Currently maps dbo (the default SQL Server schema) to public.
+   This mirrors the ALTER SCHEMA 'dbo' RENAME TO 'public' convention."
+  [^String schema]
+  (if (= (str/lower-case schema) "dbo") "public" schema))
+
 (defn- translate-next-value-for
   "Translate a SQL Server NEXT VALUE FOR [schema].[sequence] default to the
    PostgreSQL equivalent nextval('schema.sequence').
-   Returns the translated string, or nil if the input is not a NEXT VALUE FOR
-   expression.  Handles optional dbo→public schema remapping."
+   Returns the translated string, or nil and logs a warning if the input
+   starts with NEXT VALUE FOR but does not match the expected bracket syntax."
   [^String s]
-  (when-let [[_ schema seq-name]
-             (re-find #"(?i)^NEXT\s+VALUE\s+FOR\s+\[([^\]]+)\]\.\[([^\]]+)\]$"
-                      (str/trim s))]
-    (let [pg-schema (if (= (str/lower-case schema) "dbo") "public" schema)]
-      (str "nextval('" pg-schema "." seq-name "')"))))
+  (if-let [[_ schema seq-name]
+           (re-find #"(?i)^NEXT\s+VALUE\s+FOR\s+\[([^\]]+)\]\.\[([^\]]+)\]$"
+                    (str/trim s))]
+    (str "nextval('" (mssql-schema->pg schema) "." seq-name "')")
+    (do (log/warn (str "NEXT VALUE FOR default did not match expected "
+                       "[schema].[sequence] syntax, dropping: " s))
+        nil)))
 
 (defn- sanitize-default
   "Normalise MSSQL column defaults for PostgreSQL:
@@ -167,7 +176,7 @@
                                                          [(:column_name ep) (:comment ep)]))
                                                      ext-props))]
                      {:table-name table-name
-                      :schema (if (= schema "dbo") "public" schema)
+                      :schema (mssql-schema->pg schema)
                       :source-schema schema
                       :table-comment table-comment
                       :columns (mapv (fn [c]
@@ -329,7 +338,7 @@
     (->> (try (sequences conn) (catch Exception _ []))
          (mapv (fn [s]
                  (let [schema (:schema_name s)]
-                   {:schema     (if (= schema "dbo") "public" schema)
+                   {:schema     (mssql-schema->pg schema)
                     :name       (:sequence_name s)
                     :start      (:start_value s)
                     :increment  (:increment s)

--- a/clojure/src/pgloader/source/mssql.clj
+++ b/clojure/src/pgloader/source/mssql.clj
@@ -74,7 +74,7 @@
    starts with NEXT VALUE FOR but does not match the expected bracket syntax."
   [^String s]
   (if-let [[_ schema seq-name]
-           (re-find #"(?i)^NEXT\s+VALUE\s+FOR\s+\[([^\]]+)\]\.\[([^\]]+)\]$"
+           (re-find #"(?i)^NEXT VALUE FOR \[([^\]]+)\]\.\[([^\]]+)\]$"
                     (str/trim s))]
     (str "nextval('" (mssql-schema->pg schema) "." seq-name "')")
     (do (log/warn (str "NEXT VALUE FOR default did not match expected "

--- a/clojure/src/pgloader/source/mssql.clj
+++ b/clojure/src/pgloader/source/mssql.clj
@@ -323,7 +323,7 @@
   "Return a seq of sequence descriptors for all user-created SEQUENCE objects
    in the MS SQL database.  Each map contains the keys needed to emit a
    PostgreSQL CREATE SEQUENCE statement:
-     :schema :name :data-type :start :increment :min :max :cycle? :cache"
+     :schema :name :start :increment :min :max :current :cycle? :cache"
   [^MSSQLSource src]
   (let [conn (.-conn src)]
     (->> (try (sequences conn) (catch Exception _ []))
@@ -331,7 +331,6 @@
                  (let [schema (:schema_name s)]
                    {:schema     (if (= schema "dbo") "public" schema)
                     :name       (:sequence_name s)
-                    :data-type  (mssql-type->pg (:data_type s))
                     :start      (:start_value s)
                     :increment  (:increment s)
                     :min        (:minimum_value s)

--- a/clojure/src/pgloader/source/mssql.clj
+++ b/clojure/src/pgloader/source/mssql.clj
@@ -60,15 +60,30 @@
 (def ^:private numeric-pg-types
   #{"integer" "bigint" "smallint" "numeric" "double precision" "real"})
 
+(defn- translate-next-value-for
+  "Translate a SQL Server NEXT VALUE FOR [schema].[sequence] default to the
+   PostgreSQL equivalent nextval('schema.sequence').
+   Returns the translated string, or nil if the input is not a NEXT VALUE FOR
+   expression.  Handles optional dbo→public schema remapping."
+  [^String s]
+  (when-let [[_ schema seq-name]
+             (re-find #"(?i)^NEXT\s+VALUE\s+FOR\s+\[([^\]]+)\]\.\[([^\]]+)\]$"
+                      (str/trim s))]
+    (let [pg-schema (if (= (str/lower-case schema) "dbo") "public" schema)]
+      (str "nextval('" pg-schema "." seq-name "')"))))
+
 (defn- sanitize-default
-  "Drop column defaults that cannot be represented in PostgreSQL:
-   - CONVERT(…) expressions not already translated by mssql.sql (#1409)
-   - Empty-string defaults on numeric columns (#1163)"
+  "Normalise MSSQL column defaults for PostgreSQL:
+   - NEXT VALUE FOR [schema].[seq] → nextval('schema.seq')  (#1497)
+   - CONVERT(…) expressions not already translated by mssql.sql → nil (#1409)
+   - Empty-string defaults on numeric columns → nil (#1163)"
   [default pg-type]
   (when default
     (let [trimmed (str/trim default)
           lower   (str/lower-case trimmed)]
       (cond
+        ;; SQL Server sequence default → PostgreSQL nextval()
+        (str/starts-with? lower "next value for") (translate-next-value-for trimmed)
         ;; Any remaining CONVERT(…) that mssql.sql didn't map to a keyword
         (str/starts-with? lower "convert(") nil
         ;; Empty string on a numeric target type
@@ -303,6 +318,27 @@
                     :primary-key (mapv :column_name pkeys)
                     :indexes     []
                     :fkeys       []}))))))
+
+(defn catalog-sequences
+  "Return a seq of sequence descriptors for all user-created SEQUENCE objects
+   in the MS SQL database.  Each map contains the keys needed to emit a
+   PostgreSQL CREATE SEQUENCE statement:
+     :schema :name :data-type :start :increment :min :max :cycle? :cache"
+  [^MSSQLSource src]
+  (let [conn (.-conn src)]
+    (->> (try (sequences conn) (catch Exception _ []))
+         (mapv (fn [s]
+                 (let [schema (:schema_name s)]
+                   {:schema     (if (= schema "dbo") "public" schema)
+                    :name       (:sequence_name s)
+                    :data-type  (mssql-type->pg (:data_type s))
+                    :start      (:start_value s)
+                    :increment  (:increment s)
+                    :min        (:minimum_value s)
+                    :max        (:maximum_value s)
+                    :current    (:current_value s)
+                    :cycle?     (= true (:is_cycling s))
+                    :cache      (:cache_size s)}))))))
 
 (defn create-source
   [uri-map _table-spec]

--- a/clojure/src/pgloader/source/mssql.clj
+++ b/clojure/src/pgloader/source/mssql.clj
@@ -275,7 +275,7 @@
       (let [cols  (table-columns conn {:schema schema :table view-name})
             pkeys (table-pkeys   conn {:schema schema :table view-name})]
         {:table-name    view-name
-         :schema        (if (= schema "dbo") "public" schema)
+         :schema        (mssql-schema->pg schema)
          :source-schema schema
          :is-view       true
          :columns       (mapv (fn [c]
@@ -315,7 +315,7 @@
                        cols       (table-columns conn {:schema schema :table view-name})
                        pkeys      (table-pkeys   conn {:schema schema :table view-name})]
                    {:table-name  view-name
-                    :schema      (if (= schema "dbo") "public" schema)
+                    :schema      (mssql-schema->pg schema)
                     :source-schema schema
                     :is-view     true
                     :columns     (mapv (fn [c]

--- a/clojure/src/pgloader/source/mssql.sql
+++ b/clojure/src/pgloader/source/mssql.sql
@@ -1,3 +1,22 @@
+-- :name sequences :? :*
+-- :doc List all user-defined SEQUENCE objects in the current MS SQL database.
+--      IDENTITY columns do NOT appear here — they use a separate engine mechanism
+--      and are never backed by a sys.sequences row.
+SELECT s.name                                          AS sequence_name,
+       sc.name                                         AS schema_name,
+       tp.name                                         AS data_type,
+       CAST(s.start_value    AS BIGINT)                AS start_value,
+       CAST(s.increment      AS BIGINT)                AS increment,
+       CAST(s.minimum_value  AS BIGINT)                AS minimum_value,
+       CAST(s.maximum_value  AS BIGINT)                AS maximum_value,
+       CAST(s.current_value  AS BIGINT)                AS current_value,
+       s.is_cycling                                    AS is_cycling,
+       s.cache_size                                    AS cache_size
+  FROM sys.sequences  s
+  JOIN sys.schemas   sc ON sc.schema_id = s.schema_id
+  JOIN sys.types     tp ON tp.user_type_id = s.user_type_id
+ ORDER BY sc.name, s.name
+
 -- :name tables :? :*
 -- :doc List all user tables in the current MS SQL database
 SELECT TABLE_SCHEMA,

--- a/clojure/tests/Dockerfile
+++ b/clojure/tests/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p /opt/src/pgloader/build/bin \
  && make DYNSIZE=$DYNSIZE clones save
 
 # ── Stage 2: test-runner image (JRE + psql + make + pgloader v3) ──────────────
-FROM clojure:temurin-21-tools-deps-bookworm
+FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/clojure/tests/Dockerfile
+++ b/clojure/tests/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p /opt/src/pgloader/build/bin \
  && make DYNSIZE=$DYNSIZE clones save
 
 # ── Stage 2: test-runner image (JRE + psql + make + pgloader v3) ──────────────
-FROM eclipse-temurin:21-jre-jammy
+FROM clojure:temurin-21-tools-deps-bookworm
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/clojure/tests/mssql/expected/08-pkeys.out
+++ b/clojure/tests/mssql/expected/08-pkeys.out
@@ -1,10 +1,10 @@
  pk_constraints 
 ----------------
-              7
+              8
 (1 row)
 
  total_indexes 
 ---------------
-             9
+            10
 (1 row)
 

--- a/clojure/tests/mssql/expected/12-sequences.out
+++ b/clojure/tests/mssql/expected/12-sequences.out
@@ -1,0 +1,15 @@
+ sequence_exists 
+-----------------
+ t
+(1 row)
+
+ default_uses_nextval 
+----------------------
+ t
+(1 row)
+
+ rows_copied 
+-------------
+ t
+(1 row)
+

--- a/clojure/tests/mssql/init.sql
+++ b/clojure/tests/mssql/init.sql
@@ -116,6 +116,33 @@ INSERT INTO composite_child (region_id, product_id, qty) VALUES
 GO
 
 -- ============================================================
+-- #1497: SEQUENCE objects and NEXT VALUE FOR column defaults.
+--
+-- Verify that pgloader:
+--   (a) migrates the SEQUENCE itself as a PostgreSQL CREATE SEQUENCE
+--   (b) translates NEXT VALUE FOR [dbo].[order_seq] → nextval('public.order_seq')
+--       in the column default of seq_orders
+-- ============================================================
+CREATE SEQUENCE dbo.order_seq
+    AS BIGINT
+    START WITH 1000
+    INCREMENT BY 10
+    MINVALUE 1000
+    MAXVALUE 9999999999
+    NO CYCLE;
+GO
+
+-- Use NEXT VALUE FOR as a column default (issue #1497)
+CREATE TABLE seq_orders (
+    id          BIGINT DEFAULT (NEXT VALUE FOR dbo.order_seq) PRIMARY KEY,
+    description NVARCHAR(200)
+);
+GO
+
+INSERT INTO seq_orders (description) VALUES (N'First sequenced order'), (N'Second sequenced order');
+GO
+
+-- ============================================================
 -- filtertest: separate database for #1578/#1603 regression.
 --
 -- The bug: MATERIALIZE VIEWS with no INCLUDING ONLY clause

--- a/clojure/tests/mssql/sql/12-sequences.sql
+++ b/clojure/tests/mssql/sql/12-sequences.sql
@@ -1,0 +1,23 @@
+-- #1497: verify that the MSSQL SEQUENCE was migrated and the NEXT VALUE FOR
+-- column default was translated to nextval().
+
+-- The sequence itself must exist in the target schema
+SELECT EXISTS (
+    SELECT 1
+      FROM pg_sequences
+     WHERE schemaname = 'public'
+       AND sequencename = 'order_seq'
+) AS sequence_exists;
+
+-- The column default on seq_orders.id must call nextval()
+SELECT pg_get_expr(d.adbin, d.adrelid) LIKE '%nextval%' AS default_uses_nextval
+  FROM pg_attribute a
+  JOIN pg_attrdef   d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+  JOIN pg_class     c ON c.oid = a.attrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE n.nspname = 'public'
+   AND c.relname = 'seq_orders'
+   AND a.attname = 'id';
+
+-- All rows must have been copied
+SELECT COUNT(*) = 2 AS rows_copied FROM public.seq_orders;

--- a/src/load/migrate-database.lisp
+++ b/src/load/migrate-database.lisp
@@ -61,6 +61,15 @@
                              :include-drop include-drop
                              :client-min-messages :error))
 
+          ;; create sequences before tables so nextval() defaults resolve
+          (when (catalog-sequences catalog)
+            (with-stats-collection ("Create Sequences" :section :pre
+                                                       :use-result-as-read t
+                                                       :use-result-as-rows t)
+              (create-sequences catalog
+                                :include-drop include-drop
+                                :client-min-messages :error)))
+
           ;; now the tables
           (with-stats-collection ("Create tables" :section :pre
                                                   :use-result-as-read t

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -79,6 +79,7 @@
            #:catalog-schema-list
            #:catalog-types-without-btree
            #:catalog-distribution-rules
+           #:catalog-sequences
 
            #:schema-name
            #:schema-catalog
@@ -456,6 +457,7 @@
            #:create-extensions
            #:create-sqltypes
 	   #:create-schemas
+           #:create-sequences
            #:add-to-search-path
 	   #:create-tables
 	   #:create-views

--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -118,16 +118,16 @@
   "Create all sequences from CATALOG's :sequences list.
    Each entry is a plist with :schema-name :sequence-name :start-value
    :increment-by :minimum-value :maximum-value :current-value :is-cycling
-   :cache-size (as returned by fetch-sequences).
+   :cache-size (as returned by fetch-sequences).  :schema-name is already
+   mapped to the PostgreSQL name (dbo → public) by fetch-sequences.
    The start is set to current+increment so the first nextval() returns
-   the next un-issued value."
+   the next un-issued value.
+   DROP and CREATE are executed inside a single transaction per sequence
+   so that a failed CREATE does not leave behind a ghost DROP."
   (loop :for seq :in (catalog-sequences catalog)
      :for schema-name   := (getf seq :schema-name)
-     :for pg-schema     := (if (string= (string-downcase schema-name) "dbo")
-                               "public"
-                               schema-name)
      :for seq-name      := (getf seq :sequence-name)
-     :for qname         := (format nil "\"~a\".\"~a\"" pg-schema seq-name)
+     :for qname         := (format nil "\"~a\".\"~a\"" schema-name seq-name)
      :for start         := (getf seq :start-value)
      :for increment     := (getf seq :increment-by)
      :for minimum       := (getf seq :minimum-value)
@@ -137,18 +137,19 @@
      :for cache         := (getf seq :cache-size)
      :for next-val      := (if current (+ current increment) start)
      :do
-     (when include-drop
-       (pgsql-execute (format nil "DROP SEQUENCE IF EXISTS ~a CASCADE;" qname)
-                      :client-min-messages client-min-messages))
-     (pgsql-execute
-      (format nil "CREATE SEQUENCE IF NOT EXISTS ~a AS bigint~
-                   ~% START WITH ~a INCREMENT BY ~a~
-                   ~% MINVALUE ~a MAXVALUE ~a~
-                   ~%~:[NO CYCLE~;CYCLE~]~:[~; CACHE ~a~];"
-              qname next-val increment minimum maximum
-              is-cycling
-              (and cache (> cache 0)) cache)
-      :client-min-messages client-min-messages)))
+     (pomo:with-transaction ()
+       (when include-drop
+         (pgsql-execute (format nil "DROP SEQUENCE IF EXISTS ~a CASCADE;" qname)
+                        :client-min-messages client-min-messages))
+       (pgsql-execute
+        (format nil "CREATE SEQUENCE IF NOT EXISTS ~a AS bigint~
+                     ~% START WITH ~a INCREMENT BY ~a~
+                     ~% MINVALUE ~a MAXVALUE ~a~
+                     ~%~:[NO CYCLE~;CYCLE~]~:[~; CACHE ~a~];"
+                qname next-val increment minimum maximum
+                is-cycling
+                (and cache (> cache 0)) cache)
+        :client-min-messages client-min-messages))))
 
 (defun create-schemas (catalog
                        &key

--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -111,6 +111,45 @@
      :do (pgsql-execute sql :client-min-messages client-min-messages)
      :finally (return nb-tables)))
 
+(defun create-sequences (catalog
+                         &key
+                           include-drop
+                           (client-min-messages :notice))
+  "Create all sequences from CATALOG's :sequences list.
+   Each entry is a plist with :schema-name :sequence-name :start-value
+   :increment-by :minimum-value :maximum-value :current-value :is-cycling
+   :cache-size (as returned by fetch-sequences).
+   The start is set to current+increment so the first nextval() returns
+   the next un-issued value."
+  (loop :for seq :in (catalog-sequences catalog)
+     :for schema-name   := (getf seq :schema-name)
+     :for pg-schema     := (if (string= (string-downcase schema-name) "dbo")
+                               "public"
+                               schema-name)
+     :for seq-name      := (getf seq :sequence-name)
+     :for qname         := (format nil "\"~a\".\"~a\"" pg-schema seq-name)
+     :for start         := (getf seq :start-value)
+     :for increment     := (getf seq :increment-by)
+     :for minimum       := (getf seq :minimum-value)
+     :for maximum       := (getf seq :maximum-value)
+     :for current       := (getf seq :current-value)
+     :for is-cycling    := (getf seq :is-cycling)
+     :for cache         := (getf seq :cache-size)
+     :for next-val      := (if current (+ current increment) start)
+     :do
+     (when include-drop
+       (pgsql-execute (format nil "DROP SEQUENCE IF EXISTS ~a CASCADE;" qname)
+                      :client-min-messages client-min-messages))
+     (pgsql-execute
+      (format nil "CREATE SEQUENCE IF NOT EXISTS ~a AS bigint~
+                   ~% START WITH ~a INCREMENT BY ~a~
+                   ~% MINVALUE ~a MAXVALUE ~a~
+                   ~%~:[NO CYCLE~;CYCLE~]~:[~; CACHE ~a~];"
+              qname next-val increment minimum maximum
+              is-cycling
+              (and cache (> cache 0)) cache)
+      :client-min-messages client-min-messages)))
+
 (defun create-schemas (catalog
                        &key
                          include-drop
@@ -535,6 +574,7 @@ BEGIN
                                  and a.atthasdef
         WHERE relkind = 'r' and a.attnum > 0
               and pg_get_expr(d.adbin, d.adrelid) ~~ '^nextval'
+              and pg_get_serial_sequence(quote_ident(nspname) || '.' || quote_ident(relname), a.attname) is not null
               ~@[and c.oid in (select oid from reloids)~]
   LOOP
     n := n + 1;

--- a/src/pgsql/pgsql-ddl.lisp
+++ b/src/pgsql/pgsql-ddl.lisp
@@ -189,7 +189,12 @@
                         (make-column :default transformed-default)))
                   (format-default-value transformed-column))
                 (if default
-                    (ensure-quoted default #\')
+                    ;; PostgreSQL function call expressions (e.g. nextval(…)):
+                    ;; pass through as raw SQL, do not quote as string (#1497)
+                    (if (and (stringp default)
+                             (cl-ppcre:scan "^\\w+\\(" default))
+                        default
+                        (ensure-quoted default #\'))
                     (format stream "NULL")))))
 
       ;; else, when column-transform-default is nil:

--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -187,6 +187,17 @@
                           (string= "GENERATE_UUID" default)))
                  :generate-uuid)
 
+                ;; NEXT VALUE FOR [schema].[sequence] → nextval('schema.sequence') (#1497)
+                ((and (stringp default)
+                      (uiop:string-prefix-p "NEXT VALUE FOR" (string-upcase default)))
+                 (cl-ppcre:register-groups-bind (schema seq-name)
+                     ("(?i)NEXT\\s+VALUE\\s+FOR\\s+\\[([^\\]]+)\\]\\.\\[([^\\]]+)\\]"
+                      default)
+                   (let ((pg-schema (if (string= (string-downcase schema) "dbo")
+                                        "public"
+                                        schema)))
+                     (format nil "nextval('~a.~a')" pg-schema seq-name))))
+
                 ;; CONVERT(type, expr, style) defaults are SQL Server-specific
                 ;; and have no direct PostgreSQL equivalent (#1409)
                 ((and (stringp default)

--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -193,10 +193,15 @@
                  (cl-ppcre:register-groups-bind (schema seq-name)
                      ("(?i)NEXT\\s+VALUE\\s+FOR\\s+\\[([^\\]]+)\\]\\.\\[([^\\]]+)\\]"
                       default)
-                   (let ((pg-schema (if (string= (string-downcase schema) "dbo")
-                                        "public"
-                                        schema)))
-                     (format nil "nextval('~a.~a')" pg-schema seq-name))))
+                   (if (and schema seq-name)
+                       (format nil "nextval('~a.~a')"
+                               (mssql-schema->pg schema) seq-name)
+                       (progn
+                         (log-message :warning
+                                      "NEXT VALUE FOR default did not match expected ~
+                                       [schema].[sequence] syntax, dropping: ~s"
+                                      default)
+                         nil))))
 
                 ;; CONVERT(type, expr, style) defaults are SQL Server-specific
                 ;; and have no direct PostgreSQL equivalent (#1409)

--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -191,7 +191,7 @@
                 ((and (stringp default)
                       (uiop:string-prefix-p "NEXT VALUE FOR" (string-upcase default)))
                  (cl-ppcre:register-groups-bind (schema seq-name)
-                     ("(?i)NEXT\\s+VALUE\\s+FOR\\s+\\[([^\\]]+)\\]\\.\\[([^\\]]+)\\]"
+                     ("(?i)^NEXT VALUE FOR \\[([^\\]]+)\\]\\.\\[([^\\]]+)\\]$"
                       default)
                    (if (and schema seq-name)
                        (format nil "nextval('~a.~a')"

--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -23,6 +23,14 @@
   "Associate internal table type symbol with what's found in MS SQL
   information_schema.tables.table_type column.")
 
+(defun mssql-schema->pg (schema-name)
+  "Map a SQL Server schema name to its PostgreSQL equivalent.
+   Maps dbo (the default SQL Server schema) to public, following the
+   ALTER SCHEMA 'dbo' RENAME TO 'public' load-file convention."
+  (if (string= (string-downcase schema-name) "dbo")
+      "public"
+      schema-name))
+
 (defmethod filter-list-to-where-clause ((mssql copy-mssql)
                                         filter-list
                                         &key
@@ -161,18 +169,19 @@
      :finally (return catalog)))
 
 
-(defun fetch-sequences (catalog mssql)
+(defun fetch-sequences (catalog)
   "Query sys.sequences and collect them into CATALOG as a list of plists.
    Each plist has :schema-name :sequence-name :start-value :increment-by
-   :minimum-value :maximum-value :current-value :is-cycling :cache-size."
-  (declare (ignore mssql))
+   :minimum-value :maximum-value :current-value :is-cycling :cache-size.
+   Uses the implicit *mssql-db* connection established by the caller."
   (loop
+     ;; data-type (3rd column) is fetched but not used — SQL Server sequence
+     ;; types (tinyint/smallint/int/bigint/decimal) all map safely to bigint.
      :for (schema-name sequence-name data-type start-value increment-by
                        minimum-value maximum-value current-value is-cycling cache-size)
      :in (mssql-query (sql "/mssql/list-all-sequences.sql"))
-     :collect (list :schema-name   schema-name
+     :collect (list :schema-name   (mssql-schema->pg schema-name)
                     :sequence-name sequence-name
-                    :data-type     data-type
                     :start-value   start-value
                     :increment-by  increment-by
                     :minimum-value minimum-value

--- a/src/sources/mssql/mssql-schema.lisp
+++ b/src/sources/mssql/mssql-schema.lisp
@@ -161,6 +161,30 @@
      :finally (return catalog)))
 
 
+(defun fetch-sequences (catalog mssql)
+  "Query sys.sequences and collect them into CATALOG as a list of plists.
+   Each plist has :schema-name :sequence-name :start-value :increment-by
+   :minimum-value :maximum-value :current-value :is-cycling :cache-size."
+  (declare (ignore mssql))
+  (loop
+     :for (schema-name sequence-name data-type start-value increment-by
+                       minimum-value maximum-value current-value is-cycling cache-size)
+     :in (mssql-query (sql "/mssql/list-all-sequences.sql"))
+     :collect (list :schema-name   schema-name
+                    :sequence-name sequence-name
+                    :data-type     data-type
+                    :start-value   start-value
+                    :increment-by  increment-by
+                    :minimum-value minimum-value
+                    :maximum-value maximum-value
+                    :current-value current-value
+                    :is-cycling    is-cycling
+                    :cache-size    cache-size)
+     :into sequences
+     :finally (setf (catalog-sequences catalog) sequences)
+              (return catalog)))
+
+
 ;;;
 ;;; Tools to handle row queries.
 ;;;

--- a/src/sources/mssql/mssql.lisp
+++ b/src/sources/mssql/mssql.lisp
@@ -104,6 +104,9 @@
                             :including including
                             :excluding excluding))
 
+      ;; always fetch sequences — they are always created if present
+      (fetch-sequences catalog mssql)
+
       ;; return how many objects we're going to deal with in total
       ;; for stats collection
       (+ (count-tables catalog)

--- a/src/sources/mssql/mssql.lisp
+++ b/src/sources/mssql/mssql.lisp
@@ -105,7 +105,7 @@
                             :excluding excluding))
 
       ;; always fetch sequences — they are always created if present
-      (fetch-sequences catalog mssql)
+      (fetch-sequences catalog)
 
       ;; return how many objects we're going to deal with in total
       ;; for stats collection

--- a/src/sources/mssql/sql/list-all-sequences.sql
+++ b/src/sources/mssql/sql/list-all-sequences.sql
@@ -1,0 +1,17 @@
+-- List all user-defined SEQUENCE objects in the current MS SQL database.
+-- IDENTITY columns are never backed by sys.sequences — they use a separate
+-- internal engine mechanism — so no filtering is required to exclude them.
+  SELECT sc.name                       AS schema_name,
+         s.name                        AS sequence_name,
+         tp.name                       AS data_type,
+         CAST(s.start_value   AS BIGINT) AS start_value,
+         CAST(s.increment     AS BIGINT) AS increment_by,
+         CAST(s.minimum_value AS BIGINT) AS minimum_value,
+         CAST(s.maximum_value AS BIGINT) AS maximum_value,
+         CAST(s.current_value AS BIGINT) AS current_value,
+         s.is_cycling                  AS is_cycling,
+         s.cache_size                  AS cache_size
+    FROM sys.sequences  s
+    JOIN sys.schemas   sc ON sc.schema_id = s.schema_id
+    JOIN sys.types     tp ON tp.user_type_id = s.user_type_id
+ORDER BY sc.name, s.name

--- a/src/utils/catalog.lisp
+++ b/src/utils/catalog.lisp
@@ -42,7 +42,7 @@
 ;;; Column structures details depend on the specific source type and are
 ;;; implemented in each source separately.
 ;;;
-(defstruct catalog name schema-list types-without-btree distribution-rules)
+(defstruct catalog name schema-list types-without-btree distribution-rules sequences)
 
 (defstruct schema source-name name catalog in-search-path
            table-list view-list matview-list extension-list sqltype-list)


### PR DESCRIPTION
## Summary

SQL Server `SEQUENCE` objects (`sys.sequences`) are now migrated to PostgreSQL `CREATE SEQUENCE` statements. Column defaults of the form `NEXT VALUE FOR [schema].[seq]` are translated to `nextval('schema.seq')` so that target tables can be created and populated correctly.

Fixes #1497.

## Changes

### v4 (Clojure)

- **`mssql.sql`**: new HugSQL `sequences` query against `sys.sequences`
- **`mssql.clj`**: `translate-next-value-for` in `sanitize-default`; `catalog-sequences` function called by the core pipeline before table creation
- **`ddl/common.clj`**: `create-sequence-sql` / `create-sequences-sql` DDL generators; `format-default` now recognises function-call expressions (e.g. `nextval(…)`) and passes them through unquoted
- **`core.clj`**: creates sequences before tables when migrating from MSSQL

### v3 (Common Lisp)

- **`list-all-sequences.sql`**: new SQL file querying `sys.sequences`
- **`mssql-schema.lisp`**: `fetch-sequences` collects sequences into the catalog
- **`mssql.lisp`**: `fetch-sequences` called unconditionally in `fetch-metadata`
- **`catalog.lisp`**: `sequences` slot added to the `catalog` defstruct
- **`package.lisp`**: export `catalog-sequences` and `create-sequences`
- **`pgsql-create-schema.lisp`**: `create-sequences` generates DROP/CREATE SEQUENCE DDL before tables; `reset-sequences` now guards against NULL from `pg_get_serial_sequence` for non-serial `nextval()` columns
- **`pgsql-ddl.lisp`**: `format-default-value` passes function-call defaults through unquoted
- **`mssql-cast-rules.lisp`**: translates `NEXT VALUE FOR` to `nextval()` in the cast cond
- **`migrate-database.lisp`**: calls `create-sequences` in `prepare-pgsql-database`

### Tests

- **`init.sql`**: adds `dbo.order_seq` and `seq_orders` table with `NEXT VALUE FOR` default
- **`sql/12-sequences.sql`** + **`expected/12-sequences.out`**: regression test verifying sequence existence, `nextval()` default, and row count
- **`expected/08-pkeys.out`**: updated for the new seq_orders PK and index

## Testing

Both v3 and v4 MSSQL integration tests pass locally:

```
make -C clojure/tests mssql      # v4: all 12 tests ok
make -C clojure/tests mssql-v3   # v3: all 11 tests ok (04-indexes excluded for v3)
```
