### PR TITLE
fix(mysql): correct charset encoding aliases for latin1, latin5, latin7-estonian-cs, cp850-binary

### DIFF
--- a/clojure/src/pgloader/source/mysql.clj
+++ b/clojure/src/pgloader/source/mysql.clj
@@ -95,6 +95,28 @@
           ["geometry" "point" "linestring" "polygon"
            "multipoint" "multilinestring" "multipolygon" "geometrycollection"])))
 
+;;; MySQL charset names that do not match the encoding they actually store.
+;;; Applied to the charset returned by DECODING-AS rules before issuing SET NAMES,
+;;; so the MySQL server sends bytes that Connector/J can correctly decode.
+;;;
+;;;   latin1 — MySQL documents this as Windows cp1252 (not ISO 8859-1).
+;;;            They share 0x00-0x7F and 0xA0-0xFF but differ in 0x80-0x9F,
+;;;            where cp1252 has 27 printable characters (€, –, ™ …) that
+;;;            ISO 8859-1 leaves undefined as C1 control codes.
+;;;
+;;;   latin5 — MySQL latin5 is ISO 8859-9 (Turkish). SET NAMES 'latin5' is
+;;;            already correct server-side (MySQL converts to UTF-8 properly),
+;;;            so no remapping is needed for the SET NAMES path.
+(def ^:private mysql-charset-aliases
+  {"latin1" "cp1252"})
+
+(defn- normalize-mysql-charset
+  "Map MySQL charset names that alias wrong encodings to their correct names
+   for the SET NAMES call.  MySQL's latin1 is actually cp1252 (Windows-1252):
+   they share 0x00-0x7F and 0xA0-0xFF but differ in 0x80-0x9F."
+  [charset]
+  (get mysql-charset-aliases charset charset))
+
 (defn- decoding-as-charset
   "Return the charset for TABLE-NAME by matching against DECODING-AS rules,
    or nil if no rule matches."
@@ -333,7 +355,8 @@
   (read-rows [_ table-spec-entry]
     (let [{:keys [table-name source-table-name columns citus-read-sql]} table-spec-entry
           mysql-table (or source-table-name table-name)]
-      (when-let [charset (decoding-as-charset mysql-table decoding-rules)]
+      (when-let [charset (normalize-mysql-charset
+                          (decoding-as-charset mysql-table decoding-rules))]
         (try
           (jdbc/execute! conn [(str "SET NAMES '" charset "'")])
           (log/info (str "SET NAMES '" charset "' for table " mysql-table))

--- a/clojure/tests/mysql/mytest/expected/01-tables.out
+++ b/clojure/tests/mysql/mytest/expected/01-tables.out
@@ -16,6 +16,7 @@
  geom
  hex_binary
  history
+ latin1_encoding
  measurements
  on_update_ts
  onupdate
@@ -32,5 +33,5 @@
  utilisateurs__Yvelines2013-06-28
  uw_defined_meaning
  zero_dates_notnull
-(32 rows)
+(33 rows)
 

--- a/clojure/tests/mysql/mytest/expected/01-tables.v3.out
+++ b/clojure/tests/mysql/mytest/expected/01-tables.v3.out
@@ -16,6 +16,7 @@
  geom
  hex_binary
  history
+ latin1_encoding
  measurements
  on_update_ts
  onupdate
@@ -32,5 +33,5 @@
  utilisateurs__Yvelines2013-06-28
  uw_defined_meaning
  zero_dates_notnull
-(32 rows)
+(33 rows)
 

--- a/clojure/tests/mysql/mytest/expected/03-indexes.out
+++ b/clojure/tests/mysql/mytest/expected/03-indexes.out
@@ -26,6 +26,7 @@
  idx_{oid}_PRIMARY
  idx_{oid}_PRIMARY
  idx_{oid}_PRIMARY
+ idx_{oid}_PRIMARY
  idx_{oid}_ak_countdata_idx
  idx_{oid}_domain_filter
  idx_{oid}_domain_filter_unq
@@ -38,5 +39,5 @@
  idx_{oid}_search
  idx_{oid}_update_type
  idx_{oid}_url
-(38 rows)
+(39 rows)
 

--- a/clojure/tests/mysql/mytest/expected/03-indexes.v3.out
+++ b/clojure/tests/mysql/mytest/expected/03-indexes.v3.out
@@ -26,6 +26,7 @@
  idx_{oid}_PRIMARY
  idx_{oid}_PRIMARY
  idx_{oid}_PRIMARY
+ idx_{oid}_PRIMARY
  idx_{oid}_ak_countdata_idx
  idx_{oid}_domain_filter
  idx_{oid}_domain_filter_unq
@@ -38,5 +39,5 @@
  idx_{oid}_search
  idx_{oid}_update_type
  idx_{oid}_url
-(38 rows)
+(39 rows)
 

--- a/clojure/tests/mysql/mytest/expected/12-pkeys.out
+++ b/clojure/tests/mysql/mytest/expected/12-pkeys.out
@@ -1,10 +1,10 @@
  pk_constraints 
 ----------------
-             26
+             27
 (1 row)
 
  total_indexes 
 ---------------
-            38
+            39
 (1 row)
 

--- a/clojure/tests/mysql/mytest/expected/12-pkeys.v3.out
+++ b/clojure/tests/mysql/mytest/expected/12-pkeys.v3.out
@@ -1,10 +1,10 @@
  pk_constraints 
 ----------------
-             26
+             27
 (1 row)
 
  total_indexes 
 ---------------
-            38
+            39
 (1 row)
 

--- a/clojure/tests/mysql/mytest/expected/15-latin1-encoding.out
+++ b/clojure/tests/mysql/mytest/expected/15-latin1-encoding.out
@@ -1,0 +1,8 @@
+   label   | word  |       hex        
+-----------+-------+------------------
+ euro      | €     | e282ac
+ en_dash   | –     | e28093
+ trademark | ™     | e284a2
+ cafe_euro | café€ | 636166c3a9e282ac
+(4 rows)
+

--- a/clojure/tests/mysql/mytest/mytest.sql
+++ b/clojure/tests/mysql/mytest/mytest.sql
@@ -432,6 +432,29 @@ INSERT INTO zero_dates_notnull (label, created_at, updated_at) VALUES
   ('null-upd','2024-06-02 09:00:00', NULL);
 
 -- ============================================================
+-- #1368: latin1 charset encoding — MySQL latin1 is cp1252, not iso-8859-1.
+-- The two encodings differ in the range 0x80–0x9F: cp1252 maps those bytes
+-- to printable characters (€ 0x80, – 0x96, ™ 0x99, …) while ISO 8859-1
+-- leaves them as C1 control codes.  pgloader must decode them as cp1252.
+-- ============================================================
+CREATE TABLE `latin1_encoding` (
+  id    INT AUTO_INCREMENT PRIMARY KEY,
+  label VARCHAR(30)  NOT NULL,
+  word  VARCHAR(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- Rows use raw cp1252 byte values (hex literals with _latin1 introducer).
+-- Note: iso-8859-1 and cp1252 agree on 0x00-0x7F and 0xA0-0xFF; the
+-- difference is 0x80-0x9F, where cp1252 has printable chars.
+--   0x80 = € (U+20AC)    0x96 = – (U+2013)    0x99 = ™ (U+2122)
+--   0xE9 = é (U+00E9)  — this byte is identical in both encodings
+INSERT INTO `latin1_encoding` (label, word) VALUES
+  ('euro',      _latin1 x'80'),          -- € U+20AC  (cp1252 0x80, undefined in iso-8859-1)
+  ('en_dash',   _latin1 x'96'),          -- – U+2013  (cp1252 0x96, undefined in iso-8859-1)
+  ('trademark', _latin1 x'99'),          -- ™ U+2122  (cp1252 0x99, undefined in iso-8859-1)
+  ('cafe_euro', _latin1 x'636166e980'); -- café€: c(63)a(61)f(66)é(e9)€(80)
+
+-- ============================================================
 -- Grants
 -- ============================================================
 GRANT SELECT ON pgloader_mytest.* TO 'pgloader'@'%';

--- a/clojure/tests/mysql/mytest/sql/15-latin1-encoding.sql
+++ b/clojure/tests/mysql/mytest/sql/15-latin1-encoding.sql
@@ -1,0 +1,8 @@
+-- #1368: verify cp1252 bytes in a latin1 MySQL column arrive as correct Unicode.
+-- If pgloader mis-decodes latin1 as iso-8859-1, bytes 0x80-0x9F become C1 control
+-- characters (e.g. 0x80→U+0080) rather than their cp1252 code points (€, –, ™).
+SELECT label,
+       word,
+       encode(word::bytea, 'hex') AS hex
+  FROM mytest.latin1_encoding
+ ORDER BY id;

--- a/src/sources/mysql/mysql-connection.lisp
+++ b/src/sources/mysql/mysql-connection.lisp
@@ -7,6 +7,73 @@
 (defvar *connection* nil "Current MySQL connection")
 
 ;;;
+;;; qmynd maps MySQL charset/collation IDs to Babel encoding keywords, but
+;;; several mappings are wrong because MySQL's charset names don't match the
+;;; actual encoding stored on disk:
+;;;
+;;;   * latin1  — MySQL documents it as cp1252 (Windows-1252).  The two share
+;;;               all code points in 0x00–0x7F and 0xA0–0xFF but differ in
+;;;               0x80–0x9F: ISO 8859-1 treats those 32 positions as C1 control
+;;;               characters while cp1252 maps them to printable characters
+;;;               (€ 0x80, – 0x96, ™ 0x99, …).  qmynd maps all latin1
+;;;               collations to :iso-8859-1 — silently corrupting any byte in
+;;;               0x80–0x9F.
+;;;
+;;;   * latin5  — MySQL uses this name for ISO 8859-9 (Turkish), not ISO 8859-5
+;;;               (Cyrillic).  qmynd maps latin5 to :iso-8859-5, which will
+;;;               mis-decode the entire 0xA0–0xFF range for Turkish text.
+;;;
+;;;   * latin7-estonian-cs (collation 20) — qmynd maps it to :iso-8859-7
+;;;               (Greek) instead of :iso-8859-13 (Baltic/Latvian), which is
+;;;               correct for all other latin7 collations in qmynd.
+;;;
+;;; cp850   — DOS Latin-1.  The system Babel (cl-babel Debian package) does
+;;;           NOT ship an enc-cp850.lisp; returning :cp850 would raise an
+;;;           unknown-encoding error at runtime.  qmynd already punts
+;;;           cp850-general-ci to :iso-8859-1; we leave that as-is.
+;;;           cp850-binary (collation 80) is absent from qmynd's ecase and
+;;;           would cause a run-time ecase-failure; we add it here as the same
+;;;           :iso-8859-1 punt that qmynd uses for cp850-general-ci.
+;;;
+;;; We redefine qmynd-impl::mysql-cs-coll-to-character-encoding here (after
+;;; qmynd is fully loaded) rather than patching the vendored library, so that
+;;; upgrading qmynd cannot silently revert the fix.  Collation IDs are written
+;;; as integer literals rather than #.(list ...) reader macros so the
+;;; redefinition is safe across SBCL image save/restore.
+;;;   latin1-german1-ci=5  latin1-swedish-ci=8   latin1-danish-ci=15
+;;;   latin1-german2-ci=31 latin1-binary=47       latin1-general-ci=48
+;;;   latin1-general-cs=49 latin1-spanish-ci=94
+;;;   latin5-turkish-ci=21 latin5-binary=196
+;;;   latin7-estonian-cs=20
+;;;   cp850-binary=80
+;;;
+;; Store the original before redefining so the closure below can delegate.
+;; defvar rather than a let-captured variable so the function object is
+;; explicitly rooted in the image and survives SBCL save/restore cleanly.
+(defvar *qmynd-original-cs-coll-fn*
+  #'qmynd-impl::mysql-cs-coll-to-character-encoding)
+
+(defun qmynd-impl::mysql-cs-coll-to-character-encoding (cs-coll)
+  ;; Collation IDs as integer literals (no #. reader macros) for safety.
+  ;; latin1-german1-ci=5  latin1-swedish-ci=8   latin1-danish-ci=15
+  ;; latin1-german2-ci=31 latin1-binary=47       latin1-general-ci=48
+  ;; latin1-general-cs=49 latin1-spanish-ci=94
+  ;; latin5-turkish-ci=21 latin5-binary=196
+  ;; latin7-estonian-cs=20
+  ;; cp850-binary=80  (cp850-general-ci=4 left to original: same :iso-8859-1)
+  (case cs-coll
+    ;; MySQL latin1 is Windows cp1252, not ISO 8859-1.
+    ((5 8 15 31 47 48 49 94) :cp1252)
+    ;; MySQL latin5 is ISO 8859-9 (Turkish), not ISO 8859-5 (Cyrillic).
+    ((21 196) :iso-8859-9)
+    ;; latin7-estonian-cs should be ISO 8859-13; qmynd has it as :iso-8859-7.
+    ((20) :iso-8859-13)
+    ;; cp850-binary (80) absent from qmynd's ecase: same :iso-8859-1 punt.
+    ((80) :iso-8859-1)
+    (otherwise
+     (funcall *qmynd-original-cs-coll-fn* cs-coll))))
+
+;;;
 ;;; General utility to manage MySQL connection
 ;;;
 (defclass mysql-connection (db-connection)


### PR DESCRIPTION
## Problem (Closes #1368)

MySQL charset names don't always match the actual encoding stored on disk:

| MySQL charset name | qmynd returned | Correct encoding | Impact |
|---|---|---|---|
| **latin1** | `:iso-8859-1` | `:cp1252` | Bytes 0x80–0x9F (€, –, ™, …) silently corrupted |
| **latin5** | `:iso-8859-5` (Cyrillic) | `:iso-8859-9` (Turkish) | Entire 0xA0–0xFF range mis-decoded for Turkish text |
| **latin7-estonian-cs** (collation 20) | `:iso-8859-7` (Greek) | `:iso-8859-13` (Baltic) | Wrong charset for Estonian latin7 collation |
| **cp850-binary** (collation 80) | *(absent from qmynd's ecase → runtime error)* | `:iso-8859-1` punt | Type-error for any DB using this collation |

## Fix

### v3 (Common Lisp / qmynd)

Redefines `qmynd-impl::mysql-cs-coll-to-character-encoding` in `mysql-connection.lisp` after qmynd is loaded, using a `defvar` to hold the original function. Collation IDs are written as integer literals (not `#.` reader macros) to survive SBCL image save/restore cleanly. Unknown collations delegate to the original.

### v4 (Clojure / JDBC)

With `characterEncoding=UTF-8`, MySQL does server-side conversion for the default path — latin1 data is already correct. But when a user writes `DECODING TABLE NAMES MATCHING … AS latin1`, pgloader issues `SET NAMES 'latin1'` which can misfire. `normalize-mysql-charset` maps `"latin1" → "cp1252"` in that call.

## Tests

New `latin1_encoding` table in `mytest.sql` stores four rows with cp1252-only bytes (€=0x80, –=0x96, ™=0x99, café€) using `_latin1 X'..'` hex literals. New `sql/15-latin1-encoding.sql` verifies the UTF-8 round-trip. Both v3 and v4 test suites pass all 15 tests.

<details>
<summary>Verified round-trip (v3 and v4, identical output)</summary>

```
   label   | word  |       hex
-----------+-------+------------------
 euro      | €     | e282ac
 en_dash   | –     | e28093
 trademark | ™     | e284a2
 cafe_euro | café€ | 636166c3a9e282ac
(4 rows)
```
</details>