### PR TITLE
fix(pgsql): omit DEFAULT NULL clause when column-default is :NULL

### DIFF
--- a/src/pgsql/pgsql-ddl.lisp
+++ b/src/pgsql/pgsql-ddl.lisp
@@ -156,7 +156,7 @@
             typemod
             typemod
             (column-nullable column)
-            (column-default column)
+            (and (column-default column) (not (eq (column-default column) :NULL)))
             (format-default-value column))))
 
 (defvar *pgsql-default-values*


### PR DESCRIPTION
Cherry-pick of @mayerrobert's fix from #1609, rebased on current main.

## Problem

Nullable columns with no explicit default get their `column-default` normalized to `:null` by the MSSQL, MySQL, and SQLite cast rules (e.g. `mssql-cast-rules.lisp` line 168: `((and (null default) (column-nullable pgcol)) :null)`).

The CL format directive `~:[~; default ~a~]` treats `:null` as truthy (it is a non-nil keyword), so the generated `CREATE TABLE` spuriously included `DEFAULT NULL` for every such nullable column:

```sql
CREATE TABLE public.customers (
  email   text default NULL,   -- no explicit default in source
  score   float default NULL,  -- no explicit default in source
  ...
);
```

PostgreSQL silently discards `DEFAULT NULL` on nullable columns (nothing is stored in `pg_attrdef`), so there is no data-correctness impact — but the DDL output is noisy and differs from what the source database defined.

## Fix

Wrap the format test: `(and (column-default column) (not (eq (column-default column) :NULL)))` so the `default` clause is suppressed when column-default is `:null`.

## v4

Not affected — v4 stores `nil` (JDBC null) or the string `"NULL"` and the `column-def` function already gates on `(when (and column-default (not= "NULL" (str column-default))))`.

## Conflict resolution

The original PR #1609 conflicted with the `effective-type-mod` refactor that landed after it was submitted. Resolution: keep `effective-type-mod` (HEAD) and apply the `:NULL` guard to that version.

Closes #1609.