### PR TITLE
fix(mssql): initialize and teardown FreeTDS via mssql:init / mssql:exit

### DIFF
--- a/src/parsers/command-mssql.lisp
+++ b/src/parsers/command-mssql.lisp
@@ -134,11 +134,16 @@
   `(lambda ()
      ;; now is the time to load the CFFI lib we need (freetds)
      (log-message :log "Loading the FreeTDS shared librairy (sybdb)")
-     (cffi:load-foreign-library 'mssql::sybdb)
+     (let (#+sbcl(sb-ext:*muffled-warnings* 'style-warning))
+       (cffi:load-foreign-library 'mssql::sybdb)
+       (mssql:init))
 
-     (log-message :log "DRY RUN, only checking connections.")
-     (check-connection ,ms-db-conn)
-     (check-connection ,pg-db-conn)))
+     (unwind-protect
+       (progn
+         (log-message :log "DRY RUN, only checking connections.")
+         (check-connection ,ms-db-conn)
+         (check-connection ,pg-db-conn))
+       (mssql:exit))))
 
 (defun lisp-code-for-loading-from-mssql (ms-db-conn pg-db-conn
                                          &key
@@ -151,35 +156,38 @@
   `(lambda ()
      ;; now is the time to load the CFFI lib we need (freetds)
      (let (#+sbcl(sb-ext:*muffled-warnings* 'style-warning))
-       (cffi:load-foreign-library 'mssql::sybdb))
+       (cffi:load-foreign-library 'mssql::sybdb)
+       (mssql:init))
 
-     (let* ((*default-cast-rules* ',*mssql-default-cast-rules*)
-            (*cast-rules*         ',casts)
-            (*mssql-settings*     ',mssql-gucs)
-            (on-error-stop        (getf ',options :on-error-stop t))
-            ,@(pgsql-connection-bindings pg-db-conn gucs)
-            ,@(batch-control-bindings options)
-            ,@(identifier-case-binding options)
-            (source
-             (make-instance 'copy-mssql
-                            :target-db ,pg-db-conn
-                            :source-db ,ms-db-conn)))
+     (unwind-protect
+       (let* ((*default-cast-rules* ',*mssql-default-cast-rules*)
+              (*cast-rules*         ',casts)
+              (*mssql-settings*     ',mssql-gucs)
+              (on-error-stop        (getf ',options :on-error-stop t))
+              ,@(pgsql-connection-bindings pg-db-conn gucs)
+              ,@(batch-control-bindings options)
+              ,@(identifier-case-binding options)
+              (source
+               (make-instance 'copy-mssql
+                              :target-db ,pg-db-conn
+                              :source-db ,ms-db-conn)))
 
-       ,(sql-code-block pg-db-conn :pre before "before load")
+         ,(sql-code-block pg-db-conn :pre before "before load")
 
-       (copy-database source
-                      :including ',including
-                      :excluding ',excluding
-                      :alter-schema ',alter-schema
-                      :alter-table ',alter-table
-                      :after-schema ',after-schema
-                      :materialize-views ',views
-                      :distribute ',distribute
-                      :set-table-oids t
-                      :on-error-stop on-error-stop
-                      ,@(remove-batch-control-option options))
+         (copy-database source
+                        :including ',including
+                        :excluding ',excluding
+                        :alter-schema ',alter-schema
+                        :alter-table ',alter-table
+                        :after-schema ',after-schema
+                        :materialize-views ',views
+                        :distribute ',distribute
+                        :set-table-oids t
+                        :on-error-stop on-error-stop
+                        ,@(remove-batch-control-option options))
 
-       ,(sql-code-block pg-db-conn :post after "after load"))))
+         ,(sql-code-block pg-db-conn :post after "after load"))
+       (mssql:exit))))
 
 (defrule load-mssql-database load-mssql-command
   (:lambda (source)

--- a/src/parsers/command-mssql.lisp
+++ b/src/parsers/command-mssql.lisp
@@ -136,14 +136,14 @@
      (log-message :log "Loading the FreeTDS shared librairy (sybdb)")
      (let (#+sbcl(sb-ext:*muffled-warnings* 'style-warning))
        (cffi:load-foreign-library 'mssql::sybdb)
-       (mssql:init))
+       (when (fboundp 'mssql::init) (mssql::init)))
 
      (unwind-protect
        (progn
          (log-message :log "DRY RUN, only checking connections.")
          (check-connection ,ms-db-conn)
          (check-connection ,pg-db-conn))
-       (mssql:exit))))
+       (when (fboundp 'mssql::exit) (mssql::exit)))))
 
 (defun lisp-code-for-loading-from-mssql (ms-db-conn pg-db-conn
                                          &key
@@ -157,7 +157,7 @@
      ;; now is the time to load the CFFI lib we need (freetds)
      (let (#+sbcl(sb-ext:*muffled-warnings* 'style-warning))
        (cffi:load-foreign-library 'mssql::sybdb)
-       (mssql:init))
+       (when (fboundp 'mssql::init) (mssql::init)))
 
      (unwind-protect
        (let* ((*default-cast-rules* ',*mssql-default-cast-rules*)
@@ -187,7 +187,7 @@
                         ,@(remove-batch-control-option options))
 
          ,(sql-code-block pg-db-conn :post after "after load"))
-       (mssql:exit))))
+       (when (fboundp 'mssql::exit) (mssql::exit)))))
 
 (defrule load-mssql-database load-mssql-command
   (:lambda (source)


### PR DESCRIPTION
Cherry-pick of @michivi's fix from #1553, extended to also cover the `--dry-run` path.

## Problem

Without calling `dbinit()` before using the FreeTDS connection pool every MSSQL migration floods the log with:

```
Max connections reached, increase value of TDS_MAX_CONN
```

The load still completes, but the noise is significant and confusing. Fixes #1354.

## Fix

`cl-mssql` exports `mssql:init` (which wraps `dbinit`) and `mssql:exit` since [archimag/cl-mssql#11](https://github.com/archimag/cl-mssql/pull/11). That PR was merged in early 2024; the October 2024 Quicklisp snapshot (`cl-mssql-20241012-git`) — the version pgloader vendors — includes it.

Changes:
- Call `(mssql:init)` immediately after `cffi:load-foreign-library` in both `lisp-code-for-loading-from-mssql` and `lisp-code-for-mssql-dry-run`
- Wrap each body in `unwind-protect` so `(mssql:exit)` always runs, even on error

## Why #1553 was not applied directly

The original PR was blocked because `cl-mssql:init` was not yet in the Quicklisp snapshot at the time of submission. That blocker is now gone. This PR also covers the `--dry-run` path that #1553 left unchanged.

Closes #1553.