### PR TITLE
fix(pgsql): add verify-full to supported sslmode values

### DIFF
--- a/docs/command.rst
+++ b/docs/command.rst
@@ -278,7 +278,7 @@ Where:
     *user* and *password*.
 
     The *sslmode* parameter values can be one of `disable`, `allow`,
-    `prefer` or `require`.
+    `prefer`, `require` or `verify-full`.
 
     For backward compatibility reasons, it's possible to specify the
     *tablename* option directly, without spelling out the `tablename=`

--- a/src/parsers/command-db-uri.lisp
+++ b/src/parsers/command-db-uri.lisp
@@ -130,11 +130,13 @@
 (defrule dsn-option-ssl-allow   "allow"   (:constant :try))
 (defrule dsn-option-ssl-prefer  "prefer"  (:constant :try))
 (defrule dsn-option-ssl-require "require" (:constant :yes))
+(defrule dsn-option-ssl-verify-full "verify-full" (:constant :full))
 
 (defrule dsn-option-ssl (and "sslmode" "=" (or dsn-option-ssl-disable
                                                dsn-option-ssl-allow
                                                dsn-option-ssl-prefer
-                                               dsn-option-ssl-require))
+                                               dsn-option-ssl-require
+                                               dsn-option-ssl-verify-full))
   (:lambda (ssl)
     (destructuring-bind (key e val) ssl
       (declare (ignore key e))
@@ -274,4 +276,3 @@
   `((*pg-settings* (pgloader.pgsql:sanitize-user-gucs ',gucs))
     (*pgsql-reserved-keywords*
      (pgloader.pgsql:list-reserved-keywords ,pg-db-uri))))
-


### PR DESCRIPTION
Cherry-pick of @ragne's fix from #1704.

## Problem

The v3 pgloader URI parser only accepted `disable`, `allow`, `prefer`, and `require` for `sslmode`. Users connecting to services that require SNI (e.g. Databricks Lakebase) had no working option, as none of the existing modes pass the server hostname to the TLS layer.

## Fix

Add `verify-full` → `:full` mapping to the `dsn-option-ssl` parser rule. This maps to the `:full` SSL mode in cl-postgres (Postmodern), which passes the hostname to the TLS layer enabling SNI.

Note on semantics: cl-postgres `:full` is not identical to libpq `verify-full`. In libpq, `verify-full` additionally verifies the server certificate hostname; in cl-postgres, `:full` primarily enables SNI. This is the closest available mapping.

## v4

v4 already supports `verify-full` (and any other `sslmode` value) with no code change. `parse-uri` in `ast.clj` preserves the raw query string from the connection URI and appends it verbatim to the JDBC URL:

```
postgresql://host/db?sslmode=verify-full
  → jdbc:postgresql://host/db?sslmode=verify-full
```

PgJDBC handles all standard `sslmode` values natively, so query parameters pass straight through to the driver.

Based on the original fix by @ragne in #1704.