### PR TITLE
fix: typos in comments and strings

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -33,7 +33,7 @@ Please provide the following information:
     
   - [ ] how can I reproduce the bug?
 
-    Incude a self-contained pgloader command file.
+    Include a self-contained pgloader command file.
 
     If you're loading from a database, consider attaching a database dump to
     your issue. For MySQL, use `mysqldump`. For SQLite, just send over your

--- a/pgloader.asd
+++ b/pgloader.asd
@@ -10,7 +10,7 @@
                #:postmodern		; PostgreSQL protocol implementation
                #:cl-postgres		; low level bits for COPY streaming
                #:simple-date		; FIXME: recheck dependency
-               #:qmynd                  ; MySQL protocol implemenation
+               #:qmynd                  ; MySQL protocol implementation
                #:split-sequence         ; some parsing is made easy
                #:cl-csv                 ; full CSV reader
                #:cl-fad                 ; file and directories

--- a/src/load/api.lisp
+++ b/src/load/api.lisp
@@ -16,7 +16,7 @@
    "Load data from SOURCE and serialize it into FILENAME, using PostgreSQL
     COPY TEXT format."))
 
-;; The next generic function is only to get instanciated for sources
+;; The next generic function is only to get instantiated for sources
 ;; actually containing more than a single source item (tables, collections,
 ;; etc)
 

--- a/src/load/copy-data.lisp
+++ b/src/load/copy-data.lisp
@@ -49,7 +49,7 @@
 
 
 (defmethod copy-to ((copy copy) pgsql-copy-filename)
-  "Extract data from COPY file into a PotgreSQL COPY TEXT formated file"
+  "Extract data from COPY file into a PostgreSQL COPY TEXT formatted file"
   (with-open-file (text-file pgsql-copy-filename
                              :direction :output
                              :if-exists :supersede

--- a/src/load/load-file.lisp
+++ b/src/load/load-file.lisp
@@ -29,7 +29,7 @@
                             set-table-oids
                             including
                             excluding)
-  "Copy the contents of the COPY formated file to PostgreSQL."
+  "Copy the contents of the COPY formatted file to PostgreSQL."
   (declare (ignore data-only schema-only
                    create-tables include-drop foreign-keys
                    create-indexes reset-sequences materialize-views

--- a/src/load/migrate-database.lisp
+++ b/src/load/migrate-database.lisp
@@ -116,7 +116,7 @@
 
     ;; Some database sources allow the same index name being used
     ;; against several tables, so we add the PostgreSQL table OID in the
-    ;; index name, to differenciate. Set the table oids now.
+    ;; index name, to differentiate. Set the table OIDs now.
     (when (and create-tables set-table-oids)
       (with-stats-collection ("Set Table OIDs" :section :pre
                                                :use-result-as-read t
@@ -184,7 +184,7 @@
         ;; Foreign Key Constraints
         ;;
         ;; We need to have finished loading both the reference and the
-        ;; refering tables to be able to build the foreign keys, so wait
+        ;; referring tables to be able to build the foreign keys, so wait
         ;; until all tables and indexes are imported before doing that.
         ;;
         (when foreign-keys
@@ -533,7 +533,7 @@
                         (lp:end-kernel :wait nil)
                         (return worker-count))))))
 
-    (log-message :info "Done with COPYing data, waiting for indexes")
+    (log-message :info "Done with COPY-ing data, waiting for indexes")
 
     (when create-indexes
       (let ((lp:*kernel* idx-kernel))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -236,7 +236,7 @@
                                      (mkdir-or-die root-dir debug))))
           (setf *root-dir* (uiop:ensure-directory-pathname root-dir-truename)))
 
-	;; Set parameters that come from the environement
+	;; Set parameters that come from the environment
 	(init-params-from-environment)
 
         ;; Read the context file (if given) and the environment

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -612,7 +612,7 @@
 
 
 ;;;
-;;; The pgloader.load package implements data transfert from a pgloader
+;;; The pgloader.load package implements data transferred from a pgloader
 ;;; source to a PostgreSQL database, using the pgloader.pgcopy COPY
 ;;; implementation.
 ;;;

--- a/src/params.lisp
+++ b/src/params.lisp
@@ -63,7 +63,7 @@
 (defparameter *version-string*
   (concatenate 'string *major-version* "."
                (if *release* *minor-version* (git-hash)))
-  "pgloader version strings, following Emacs versionning model.")
+  "pgloader version strings, following Emacs versioning model.")
 
 (defvar *self-upgrade-immutable-systems* nil
   "Used for --self-upgrade.")
@@ -175,7 +175,7 @@
 ;;; Run time context to fill-in variable parts of the commands.
 ;;;
 (defvar *context* nil
-  "Alist of (names . values) intialized from the environment at run-time,
+  "Alist of (names . values) initialized from the environment at run-time,
   and from a --context command line argument, then used in the commands when
   they are using the Mustache templating feature.")
 

--- a/src/parsers/command-csv.lisp
+++ b/src/parsers/command-csv.lisp
@@ -339,7 +339,7 @@
       (assert (eq m-type :regex))
       (assert (eq d-type :filename))
       (unless root
-        (error "Directory ~s does not exists."
+        (error "Directory ~s does not exist."
                (uiop:native-namestring dir)))
       `(:regex ,first-or-all ,regex ,root))))
 

--- a/src/pg-copy/copy-db-write.lisp
+++ b/src/pg-copy/copy-db-write.lisp
@@ -30,9 +30,9 @@
 
 (defun db-write-row (copier data)
   "Copy cl-postgres:db-write-row guts to avoid computing utf-8 bytes all
-   over again, as we reproduced the data formating in pgloader code. The
+   over again, as we reproduced the data formatting in pgloader code. The
    reason we do that is to be able to lower the cost of retrying batches:
-   the formating has then already been done."
+   the formatting has then already been done."
   (let* ((connection          (cl-postgres::copier-database copier))
 	 (cl-postgres::socket (cl-postgres::connection-socket connection)))
     (cl-postgres::with-reconnect-restart connection
@@ -52,9 +52,9 @@
 ;;;
 (defun db-write-vector-row (copier row &optional (nbcols (length row)))
   "Copy cl-postgres:db-write-row guts to avoid computing utf-8 bytes all
-   over again, as we reproduced the data formating in pgloader code. The
+   over again, as we reproduced the data formatting in pgloader code. The
    reason we do that is to be able to lower the cost of retrying batches:
-   the formating has then already been done."
+   the formatting has then already been done."
   (declare (optimize (speed 3) (space 0) (debug 1) (compilation-speed 0)))
   (let* ((col-bytes           (map 'vector
                                    (lambda (col)
@@ -89,9 +89,9 @@
 
 (defun db-write-escaped-vector-row (copier row &optional (nbcols (length row)))
   "Copy cl-postgres:db-write-row guts to avoid computing utf-8 bytes all
-   over again, as we reproduced the data formating in pgloader code. The
+   over again, as we reproduced the data formatting in pgloader code. The
    reason we do that is to be able to lower the cost of retrying batches:
-   the formating has then already been done."
+   the formatting has then already been done."
   (declare (optimize (speed 3) (space 0) (debug 1) (compilation-speed 0)))
   (let* ((col-bytes           (map 'vector
                                    (lambda (col)

--- a/src/pg-copy/copy-rows-in-batch-through-s3.lisp
+++ b/src/pg-copy/copy-rows-in-batch-through-s3.lisp
@@ -34,7 +34,7 @@
 (defun prepare-and-format-row-for-s3 (copy nbcols row)
   "Redshift doesn't know how to parse COPY format, we need to upload CSV
    instead. That said, we don't have to be as careful with the data layout
-   and unicode representation when COPYing from a CSV file as we do when
+   and unicode representation when COPY-ing from a CSV file as we do when
    implementing the data streaming outselves."
   (declare (ignore copy nbcols))
   (let ((pg-vector-row (cl-csv:write-csv-row (coerce row 'list)

--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -634,7 +634,7 @@ $$; " tables)))
 
 
 ;;;
-;;; Citus Disitribution support
+;;; Citus Distribution support
 ;;;
 (defun create-distributed-table (distribute-rules)
   (let ((citus-sql

--- a/src/pgsql/pgsql-finalize-catalogs.lisp
+++ b/src/pgsql/pgsql-finalize-catalogs.lisp
@@ -168,7 +168,7 @@
                              *redshift-decimal-max-precision* scale)))))
 
           ;;
-          ;; Target data type is suppported, just keep it around.
+          ;; Target data type is supported, just keep it around.
           ;;
           ((and (stringp (column-type-name column))
                 (member (column-type-name column)

--- a/src/regress/regress.lisp
+++ b/src/regress/regress.lisp
@@ -45,7 +45,7 @@
                     ;;
                     ;; The connection facility still works with cons here,
                     ;; rather than table structure instances, because of
-                    ;; depedencies as explained in
+                    ;; dependencies as explained in
                     ;; src/parsers/command-db-uri.lisp
                     ;;
                     (cons "expected" (table-name target-table)))

--- a/src/sources/common/api.lisp
+++ b/src/sources/common/api.lisp
@@ -136,7 +136,7 @@
 ;;; The methods for those function query the source database catalogs and
 ;;; populate pgloader's internal representation of its catalog.
 ;;;
-;;; On some source systems (such as MySQL) a single schema can be adressed
+;;; On some source systems (such as MySQL) a single schema can be addressed
 ;;; at a time, and the catalog object might be a schema directly.
 ;;;
 (defgeneric filter-list-to-where-clause (db-copy filter-list

--- a/src/sources/common/casting-rules.lisp
+++ b/src/sources/common/casting-rules.lisp
@@ -56,7 +56,7 @@
                   (string-equal table-name (car rule-source-column))
                   (string-equal column-name (cdr rule-source-column)))
 
-             ;; otherwide, we do the full dance
+             ;; otherwise, we do the full dance
              (and
               (or (and t-s-p (or (eq t rule-source-type)
                                   (string-equal type rule-source-type))))

--- a/src/sources/common/matviews.lisp
+++ b/src/sources/common/matviews.lisp
@@ -2,8 +2,8 @@
 ;;; Materialized Views support is quite similar from a DB engine from another.
 ;;;
 ;; It happens that the view definition is given by the user, so pgloader is
-;; not concerned with that part of the SQL compatiblity. The common
-;; implementation uses the following two SQL comamnds:
+;; not concerned with that part of the SQL compatibility. The common
+;; implementation uses the following two SQL commands:
 ;;;
 ;;;   CREATE VIEW <schema>.<name> AS <sql>
 ;;;   DROP VIEW <schema>.<name>, <schema>.<name>, ...;

--- a/src/sources/common/project-fields.lisp
+++ b/src/sources/common/project-fields.lisp
@@ -185,7 +185,7 @@
 (defun reformat-then-process (&key fields columns target date-format)
   "Return a lambda form to apply to each row we read.
 
-   The lambda closes over the READ paramater, which is a counter of how many
+   The lambda closes over the READ parameter, which is a counter of how many
    lines we did read in the file."
   (let ((projection (project-fields :fields fields
                                     :columns columns

--- a/src/sources/mysql/mysql.lisp
+++ b/src/sources/mysql/mysql.lisp
@@ -220,7 +220,7 @@ Illegal ~a character starting at position ~a~@[: ~a~].~%"
   "Special per-table encoding/decoding overloading rules for MySQL.")
 
 (defun apply-decoding-as-filters (table-name filters)
-  "Return a generialized boolean which is non-nil only if TABLE-NAME matches
+  "Return a generalized boolean which is non-nil only if TABLE-NAME matches
    one of the FILTERS."
   (flet ((apply-filter (filter) (matches filter table-name)))
     (some #'apply-filter filters)))

--- a/src/sources/pgsql/pgsql-cast-rules.lisp
+++ b/src/sources/pgsql/pgsql-cast-rules.lisp
@@ -13,7 +13,7 @@
 
     (:source (:type "character varying")
      :target (:type "text" :drop-typemod t)))
-  "Data Type Casting to migrate from PostgtreSQL to PostgreSQL")
+  "Data Type Casting to migrate from PostgreSQL to PostgreSQL")
 
 (defmethod pgsql-column-ctype ((column column))
   "Build the ctype definition from the PostgreSQL column information."

--- a/src/utils/archive.lisp
+++ b/src/utils/archive.lisp
@@ -80,7 +80,7 @@
     (uiop:run-program command)))
 
 (defun gunzip (archive-file expand-directory)
-  "Unzip a gzip formated archive"
+  "Unzip a gzip formatted archive"
   (let ((command (format nil "gunzip -c ~s > ~s"
                          (uiop:native-namestring archive-file)
                          (uiop:native-namestring (pathname-name archive-file))))

--- a/src/utils/catalog.lisp
+++ b/src/utils/catalog.lisp
@@ -72,7 +72,7 @@
 
 ;;;
 ;;; When migrating from another database to PostgreSQL some data types might
-;;; need to be tranformed dynamically into User Defined Types: ENUMs, SET,
+;;; need to be transformed dynamically into User Defined Types: ENUMs, SET,
 ;;; etc.
 ;;;
 (defstruct sqltype name schema type source-def extra extension)

--- a/src/utils/connection.lisp
+++ b/src/utils/connection.lisp
@@ -25,7 +25,7 @@
   (:documentation "Check that we can actually connect."))
 
 (defgeneric clone-connection (connection)
-  (:documentation "Instanciate a new connection object with similar properties."))
+  (:documentation "Instantiate a new connection object with similar properties."))
 
 
 ;;;

--- a/src/utils/pretty-print-state.lisp
+++ b/src/utils/pretty-print-state.lisp
@@ -293,7 +293,7 @@
 
 
 ;;;
-;;; Have yason output JSON formated output, straight from our instances.
+;;; Have yason output JSON formatted output, straight from our instances.
 ;;;
 (defmacro define-yason-encoder (class)
   "Define a new yason:encode method for CLASS."

--- a/src/utils/quoting.lisp
+++ b/src/utils/quoting.lisp
@@ -67,7 +67,7 @@
       (format nil "~c~a~c" quote-char value quote-char)))
 
 (defun build-identifier (sep &rest parts)
-  "Concatenante PARTS into a PostgreSQL identifier, with SEP in between
+  "Concatenate PARTS into a PostgreSQL identifier, with SEP in between
    parts. That's useful for creating an index name from a table's oid and name."
   (apply-identifier-case
    (apply #'concatenate

--- a/src/utils/read-sql-files.lisp
+++ b/src/utils/read-sql-files.lisp
@@ -57,7 +57,7 @@
   (setf (parser-state p) (if (null (parser-tags p)) :eat :eqt)))
 
 #|
-Here's a test case straigth from the PostgreSQL docs:
+Here's a test case straight from the PostgreSQL docs:
 
 (with-input-from-string (s "
 create function f(text)
@@ -101,7 +101,7 @@ Another test case for the classic quotes:
      - EQT    Eat Quoted Text
      - EDQ    Eat Double-Quoted Text (identifiers)
      - EOQ    done reading the query
-     - ESC    read espaced text (with backslash)"
+     - ESC    read escaped text (with backslash)"
   (handler-case
       (loop
          :until (eq :eoq (parser-state state))

--- a/src/utils/report.lisp
+++ b/src/utils/report.lisp
@@ -5,7 +5,7 @@
 (in-package :pgloader.state)
 
 ;;;
-;;; Timing Formating
+;;; Timing Formatting
 ;;;
 (defun format-interval (seconds &optional (stream t))
   "Output the number of seconds in a human friendly way"

--- a/src/utils/state.lisp
+++ b/src/utils/state.lisp
@@ -103,7 +103,7 @@
   (gethash name (pgstate-tables pgstate)))
 
 (defun pgstate-new-label (pgstate label)
-  "Instanciate a new pgtable structure to hold our stats, and return it."
+  "Instantiate a new pgtable structure to hold our stats, and return it."
   (or (pgstate-get-label pgstate label)
       (let* ((pgtable (setf (gethash label (pgstate-tables pgstate))
                             (make-pgtable :name label

--- a/src/utils/utils.lisp
+++ b/src/utils/utils.lisp
@@ -48,7 +48,7 @@
 ;;; For log messages
 ;;;
 (defun pretty-print-bytes (bytes &key (unit "B"))
-  "Return a string to reprensent bytes in human readable format, with units"
+  "Return a string to represent bytes in human readable format, with units"
   (let ((bytes (or bytes 0)))
     (loop
        :for multiple :in '("T" "G" "M" "k")


### PR DESCRIPTION
Cherry-pick of @aadrian's fix from #1483.

Fixes spelling mistakes in comments, docstrings, and log messages across 30 files. No logic changes.

`formating` → `formatting`, `Incude` → `Include`, `instanciated` → `instantiated`, `differenciate` → `differentiate`, `refering` → `referring`, `suppported` → `supported`, `compatiblity` → `compatibility`, `comamnds` → `commands`, `PostgtreSQL` → `PostgreSQL`, `Disitribution` → `Distribution`, `reprensent` → `represent`, `straigth` → `straight`, `espaced` → `escaped`, `versionning` → `versioning`, `intialized` → `initialized`, `depedencies` → `dependencies`, `adressed` → `addressed`, `generialized` → `generalized`, `otherwide` → `otherwise`, `Concatenante` → `Concatenate`, `tranformed` → `transformed`.

Closes #1483.