### PR TITLE
fix(parser): error at parse time when both 'batch concurrency' and 'prefetch rows' appear in WITH clause

### DIFF
--- a/clojure/src/pgloader/core.clj
+++ b/clojure/src/pgloader/core.clj
@@ -450,12 +450,15 @@
             (close! source)
             (.close ^java.sql.Connection pg-conn)
             (log/info "DRY RUN — connections OK"))
-        (let [opts-batch-rows (some-> (get (:with-options cmd) :batch-rows) (long))
-              opts-batch-size (some-> (get (:with-options cmd) :batch-size) (Long/parseLong))
-              opts-prefetch-rows (some-> (get (:with-options cmd) :prefetch-rows) (long))]
+        (let [opts-batch-rows    (some-> (get (:with-options cmd) :batch-rows) (long))
+              opts-batch-size    (some-> (get (:with-options cmd) :batch-size) (Long/parseLong))
+              opts-prefetch-rows (some-> (get (:with-options cmd) :prefetch-rows) (long))
+              opts-batch-concurr (some-> (get (:with-options cmd) :batch-concurrency) (long))
+              _ (when (and opts-prefetch-rows opts-batch-concurr)
+                  (throw (ex-info "pgloader: 'batch concurrency' (deprecated) and 'prefetch rows' cannot both appear in the same WITH clause; remove 'batch concurrency'" {})))]
           (binding [copy/*batch-rows* (or opts-batch-rows copy/*batch-rows*)
                     copy/*batch-size* (or opts-batch-size copy/*batch-size*)
-                    copy/*prefetch-queue-capacity* (or opts-prefetch-rows copy/*prefetch-queue-capacity*)]
+                    copy/*prefetch-queue-capacity* (or opts-prefetch-rows opts-batch-concurr copy/*prefetch-queue-capacity*)]
             (try
           ;; Send MySQL-specific SET params to the MySQL source connection before catalog fetch
               (when (#{:mysql :mariadb} (:type source-uri))

--- a/clojure/src/pgloader/load_file/ast.clj
+++ b/clojure/src/pgloader/load_file/ast.clj
@@ -342,6 +342,7 @@
             :batch-rows          [tag (Integer/parseInt (second (second inner)))]
             :batch-size          [tag (second (second inner))]
             :prefetch-rows       [tag (Integer/parseInt (second (second inner)))]
+            :batch-concurrency   [tag (Integer/parseInt (second (second inner)))]
             :rows-per-range      [tag (Integer/parseInt (second (second inner)))]
             :workers             [tag (Integer/parseInt (second (second inner)))]
             :concurrency         [tag (Integer/parseInt (second (second inner)))]
@@ -447,7 +448,7 @@
         :batch-size {:batch-size (second (second node))}
         :batch-concurrency {:batch-concurrency (Integer/parseInt (second (second node)))}
         :prefetch-rows {:prefetch-rows (Integer/parseInt (second (second node)))}
-        :csv-header {:csv-header true}
+        :csv-header  {:csv-header true}
         :csv-escape-mode {:escape-mode :following}
         :lines-terminated {:lines-terminated (interpret-escape (second (second node)))}
         :date-format {:date-format (second (second node))}
@@ -469,6 +470,7 @@
         :batch-rows {:batch-rows (Integer/parseInt (second (second node)))}
         :batch-size {:batch-size (second (second node))}
         :batch-concurrency {:batch-concurrency (Integer/parseInt (second (second node)))}
+        :prefetch-rows {:prefetch-rows (Integer/parseInt (second (second node)))}
         :disable-triggers {:disable-triggers true}
         :drop-indexes {:drop-indexes true}
         nil))))
@@ -487,6 +489,7 @@
         :batch-rows {:batch-rows (Integer/parseInt (second (second node)))}
         :batch-size {:batch-size (second (second node))}
         :batch-concurrency {:batch-concurrency (Integer/parseInt (second (second node)))}
+        :prefetch-rows {:prefetch-rows (Integer/parseInt (second (second node)))}
         :disable-triggers {:disable-triggers true}
         :drop-indexes {:drop-indexes true}
         nil))))
@@ -1070,13 +1073,17 @@
                           (if (and (vector? n) (= :fixed-option (first n)))
                             (let [opt (second n)]
                               (case (first opt)
-                                :truncate         (assoc acc :truncate true)
-                                :create-tables    (assoc acc :create-tables true)
-                                :create-no-tables (assoc acc :create-tables false)
-                                :fixed-header     (assoc acc :fixed-header true)
-                                :date-format      (assoc acc :date-format (second (second opt)))
-                                :drop-indexes     (assoc acc :drop-indexes true)
-                                :disable-triggers (assoc acc :disable-triggers true)
+                                :truncate          (assoc acc :truncate true)
+                                :create-tables     (assoc acc :create-tables true)
+                                :create-no-tables  (assoc acc :create-tables false)
+                                :fixed-header      (assoc acc :fixed-header true)
+                                :date-format       (assoc acc :date-format (second (second opt)))
+                                :drop-indexes      (assoc acc :drop-indexes true)
+                                :disable-triggers  (assoc acc :disable-triggers true)
+                                :batch-rows        (assoc acc :batch-rows (Integer/parseInt (second (second opt))))
+                                :batch-size        (assoc acc :batch-size (second (second opt)))
+                                :batch-concurrency (assoc acc :batch-concurrency (Integer/parseInt (second (second opt))))
+                                :prefetch-rows     (assoc acc :prefetch-rows (Integer/parseInt (second (second opt))))
                                 acc))
                             acc))
                         {}

--- a/clojure/src/pgloader/load_file/grammar.clj
+++ b/clojure/src/pgloader/load_file/grammar.clj
@@ -115,7 +115,7 @@
 
     with-fixed-clause = <'WITH'> <ws> fixed-option (<opt-ws> <','> <opt-ws> fixed-option)*
     fixed-option = truncate | create-tables | create-table | create-no-tables | batch-rows
-                 | batch-size | batch-concurrency | disable-triggers | drop-indexes | fixed-header | date-format
+                 | batch-size | batch-concurrency | prefetch-rows | disable-triggers | drop-indexes | fixed-header | date-format
     fixed-header = <'fixed'> <ws> <'header'>
 
    load-archive = <'LOAD'> <ws> <'ARCHIVE'>
@@ -131,12 +131,12 @@
     csv-filename-matching = <'FILENAME'> <ws> <'MATCHING'> <ws> file-pattern
 
    with-copy-clause = <'WITH'> <ws> copy-option (<opt-ws> <','> <opt-ws> copy-option)*
-    copy-option = truncate | create-tables | create-table | create-no-tables | option-delimiter | option-null | batch-rows | batch-size | batch-concurrency | disable-triggers | drop-indexes
+    copy-option = truncate | create-tables | create-table | create-no-tables | option-delimiter | option-null | batch-rows | batch-size | batch-concurrency | prefetch-rows | disable-triggers | drop-indexes
     option-delimiter = <'delimiter'> <opt-ws> <'='> <opt-ws> quoted-char
     option-null = <'null'> <opt-ws> <'='> <opt-ws> quoted-string
 
    with-dbf-clause = <'WITH'> <ws> dbf-option (<opt-ws> <','> <opt-ws> dbf-option)*
-    dbf-option = truncate | create-tables | create-table | create-no-tables | batch-rows | batch-size | batch-concurrency | disable-triggers | drop-indexes | dbf-encoding
+    dbf-option = truncate | create-tables | create-table | create-no-tables | batch-rows | batch-size | batch-concurrency | prefetch-rows | disable-triggers | drop-indexes | dbf-encoding
     create-table = <'create'> <ws> <'table'>
     dbf-encoding = <'encoding'> <ws> quoted-string
    having-fields = <'having'> <ws> <'fields'> <ws> column-list
@@ -165,7 +165,7 @@
     table-name  = #'[a-zA-Z_][a-zA-Z0-9_-]*' | <'\"'> #'[^\"]+' <'\"'>
 
    with-csv-clause  = <'WITH'> <ws> csv-option (<opt-ws> <','> <opt-ws> csv-option)*
-    csv-option  = skip-header | fields-enclosed | fields-terminated | fields-escaped | fields-not-enclosed | csv-encoding | create-tables | create-no-tables | nullif | keep-unquoted-blanks | trim-unquoted-blanks | truncate | disable-triggers | batch-rows | batch-size | batch-concurrency | csv-header | lines-terminated | csv-escape-mode | date-format | drop-indexes
+    csv-option  = skip-header | fields-enclosed | fields-terminated | fields-escaped | fields-not-enclosed | csv-encoding | create-tables | create-no-tables | nullif | keep-unquoted-blanks | trim-unquoted-blanks | truncate | disable-triggers | batch-rows | batch-size | batch-concurrency | prefetch-rows | csv-header | lines-terminated | csv-escape-mode | date-format | drop-indexes
     date-format = <'date'> <ws> <'format'> <ws> quoted-string
     drop-indexes = <'drop'> <ws> <'indexes'>
    csv-encoding = <'encoding'> <ws> quoted-string
@@ -192,7 +192,7 @@
 
    with-db-clause   = <'WITH'> <ws> db-option (<opt-ws> <','> <opt-ws> db-option)*
     db-option   = include-drop | create-tables | create-indexes | create-no-tables
-                | workers | concurrency | batch-rows | batch-size | prefetch-rows
+                | workers | concurrency | batch-rows | batch-size | prefetch-rows | batch-concurrency
                 | on-error-stop | on-error-resume | identifier-case
                 | multiple-readers | single-reader | rows-per-range | chunk-size
                 | include-no-drop | truncate | disable-triggers

--- a/src/parsers/command-options.lisp
+++ b/src/parsers/command-options.lisp
@@ -73,14 +73,20 @@
     (bind (((_ _ _ val) batch-size))
       (cons :batch-size val))))
 
-;;; deprecated, but still accept it in the parsing
+;;; 'batch concurrency' is deprecated; 'prefetch rows' is the current spelling.
+;;; They both control *prefetch-rows* but using both in the same WITH clause
+;;; produces undefined behavior, so we track them with different keys and error
+;;; at parse time if both appear together (see batch-control-bindings).
 (defrule option-prefetch-rows (and (or (and kw-batch kw-concurrency)
                                        (and kw-prefetch kw-rows))
                                    equal-sign
                                    (+ (digit-char-p character)))
   (:lambda (prefetch-rows)
-    (bind (((_ _ nb) prefetch-rows))
-      (cons :prefetch-rows (parse-integer (text nb))))))
+    (bind (((keyword-pair _ nb) prefetch-rows))
+      (let ((key (if (eq (first keyword-pair) :batch)
+                     :batch-concurrency
+                     :prefetch-rows)))
+        (cons key (parse-integer (text nb)))))))
 
 (defrule option-rows-per-range (and kw-rows kw-per kw-range
                                     equal-sign
@@ -90,9 +96,13 @@
 
 (defun batch-control-bindings (options)
   "Generate the code needed to add batch-control"
+  (when (and (getf options :batch-concurrency) (getf options :prefetch-rows))
+    (error "pgloader: 'batch concurrency' (deprecated) and 'prefetch rows' cannot both appear in the same WITH clause; remove 'batch concurrency'"))
   `((*copy-batch-rows* (or ,(getf options :batch-rows) *copy-batch-rows*))
     (*copy-batch-size* (or ,(getf options :batch-size) *copy-batch-size*))
-    (*prefetch-rows*   (or ,(getf options :prefetch-rows) *prefetch-rows*))
+    (*prefetch-rows*   (or ,(or (getf options :prefetch-rows)
+                                (getf options :batch-concurrency))
+                           *prefetch-rows*))
     (*rows-per-range*  (or ,(getf options :rows-per-range) *rows-per-range*))))
 
 (defun identifier-case-binding (options)
@@ -104,6 +114,7 @@
                                       (option-list '(:batch-rows
                                                      :batch-size
                                                      :prefetch-rows
+                                                     :batch-concurrency
                                                      :rows-per-range
                                                      :on-error-stop
                                                      :identifier-case))


### PR DESCRIPTION
Closes #1662. Fixes #1661.

## Problem

`batch concurrency` and `prefetch rows` both ultimately control the same prefetch-rows variable. When both appear in the same `WITH` clause, the last one parsed silently wins:

```
with batch concurrency = 3, prefetch rows = 20000
-- result: prefetch-rows = 20000  ✓

with prefetch rows = 20000, batch concurrency = 3
-- result: prefetch-rows = 3      ✗ (issue #1661)
```

## Fix (v3)

The `option-prefetch-rows` parse rule now produces **different plist keys** for the two spellings — `:batch-concurrency` for the deprecated `batch concurrency` form, `:prefetch-rows` for the current `prefetch rows` form. `batch-control-bindings` then:

- **Errors at parse time** if both keys appear together (clear message, no silent override)
- Honours `:batch-concurrency` alone for load files that use only the deprecated form (full backwards compat)

No changes needed to any of the 10 `command-*.lisp` files that reference `option-prefetch-rows`.

## Fix (v4)

The v4 grammar had the two options siloed in separate contexts — `batch concurrency` was only accepted in file-load `WITH` clauses (CSV/COPY/DBF/FIXED) and `prefetch rows` only in database-load `WITH` clauses (MySQL/MSSQL/etc.). This meant `batch concurrency` was parsed but **silently ignored** in file loads (the value was stored under `:batch-concurrency` but `core.clj` only read `:prefetch-rows`).

Changes:
- **grammar.clj**: add `prefetch-rows` to all file-load option rules; add `batch-concurrency` to `db-option`
- **ast.clj**: add `:batch-concurrency` to `hiccup->db-option`; add `:prefetch-rows` to the copy/dbf/csv/fixed option handlers; fix the fixed handler which was silently dropping `:batch-rows`/`:batch-size`
- **core.clj**: fall back to `:batch-concurrency` when `:prefetch-rows` is absent; throw `ex-info` when both appear together

## What the original PR (#1662) did differently

PR #1662 removed the `batch concurrency` alias entirely, breaking any load file that used it alone. This PR keeps it working as a deprecated alias while making the conflict a hard error.