### PR TITLE
fix(mssql): cast int IDENTITY to serial, not bigserial

### DIFF
--- a/clojure/src/pgloader/ddl/common.clj
+++ b/clojure/src/pgloader/ddl/common.clj
@@ -32,7 +32,9 @@
       (= lower "xml")    "xml"
       ;; Pass-through array types from PostgreSQL sources (#1371)
       (str/ends-with? lower "[]") lower
-      (str/starts-with? upper "BIGSERIAL")   "bigserial"
+      (str/starts-with? upper "BIGSERIAL")    "bigserial"
+      (str/starts-with? upper "SMALLSERIAL") "smallserial"
+      (str/starts-with? upper "SERIAL")      "serial"
       ;; Unsigned integers: upcast to avoid overflow (matches CL cast rules)
       (and unsigned? (str/starts-with? upper "TINYINT"))   "smallint"
       (and unsigned? (str/starts-with? upper "SMALLINT"))  "integer"

--- a/clojure/src/pgloader/source/mssql.clj
+++ b/clojure/src/pgloader/source/mssql.clj
@@ -184,7 +184,9 @@
                                              is-identity (= 1 (:is_identity c))
                                              is-pk (some #(= (:column_name c) %) (mapv :column_name pkeys))
                                              ai (and is-identity is-pk)]
-                                         (let [pg-type (if ai "bigserial" (mssql-type->pg col-type))
+                                         (let [pg-type (if ai
+                                                         (if (= col-type "bigint") "bigserial" "serial")
+                                                         (mssql-type->pg col-type))
                                                raw-def  (when-not ai (:column_default c))]
                                            {:column-name (:column_name c)
                                             :column-type pg-type

--- a/src/sources/mssql/mssql-cast-rules.lisp
+++ b/src/sources/mssql/mssql-cast-rules.lisp
@@ -13,7 +13,7 @@
     (:source (:type "xml")       :target (:type "xml" :drop-typemod t))
 
     (:source (:type "int" :auto-increment t)
-             :target (:type "bigserial" :drop-default t))
+             :target (:type "serial" :drop-default t))
     
     (:source (:type "bigint" :auto-increment t)
              :target (:type "bigserial"))


### PR DESCRIPTION
Fixes #1590. Closes #1596. Cherry-picks the correct fix from @gnarlex.

## Problem

MSSQL `int` is 32-bit. The previous default cast to `bigserial` (64-bit) was wrong:

- It silently widens the column type during migration
- Wastes storage (twice as many bytes per row for that column)
- Breaks the Node.js `pg` driver, which returns strings for `int8` values instead of JavaScript numbers, because JS cannot represent full 64-bit integers safely

## Fix

**v3** (`src/sources/mssql/mssql-cast-rules.lisp`): change the `int :auto-increment` cast rule target from `bigserial` to `serial`. The existing rules for `bigint :auto-increment` → `bigserial`, `smallint :auto-increment` → `smallserial`, and `tinyint :auto-increment` → `serial` were already correct.

**v4** (`clojure/src/pgloader/source/mssql.clj`): the source hardcoded `"bigserial"` for every IDENTITY column regardless of the source integer type. Now uses `"bigserial"` only for `bigint IDENTITY`, and `"serial"` for everything else (`int`, `smallint`, `tinyint`).

## Override

Users who relied on the old behaviour can restore it with a cast rule that matches only auto-increment `int` columns:

```
CAST type int with extra auto_increment to bigserial drop default
```