### PR TITLE
feat(docker): publish multi-arch v4 image to ghcr.io

### DIFF
--- a/.github/workflows/docker-publish-v4.yml
+++ b/.github/workflows/docker-publish-v4.yml
@@ -1,0 +1,77 @@
+name: Docker (v4)
+
+on:
+  push:
+    branches: [ main ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  # Separate image name so v3 and v4 images coexist without tag collisions.
+  IMAGE_NAME: ${{ github.repository }}-v4
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v2.2.3'
+
+      # QEMU is needed for the arm64 runtime stage (shell commands under
+      # emulation are fast; the Clojure build itself runs natively via
+      # --platform=$BUILDPLATFORM in the Dockerfile builder stage).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: clojure
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        run: cosign sign --yes ${TAGS}
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          COSIGN_EXPERIMENTAL: "true"

--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -23,7 +23,7 @@ FROM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
 # Copy the built jar
-COPY --from=builder /app/target/pgloader-v4-0.1.0-SNAPSHOT.jar /app/pgloader.jar
+COPY --from=builder /app/target/pgloader.jar /app/pgloader.jar
 
 # Create a non-root user
 RUN groupadd --system pgloader \

--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -1,5 +1,10 @@
 # Multi-stage build for pgloader Clojure v4
-FROM clojure:temurin-21-jammy AS builder
+#
+# Use BUILDPLATFORM for the builder stage so that the Clojure compilation
+# always runs on the native host architecture (linux/amd64 on GitHub Actions),
+# producing a platform-independent JAR.  The runtime stage uses TARGETPLATFORM,
+# so the correct eclipse-temurin arm64/amd64 layer is pulled from the registry.
+FROM --platform=$BUILDPLATFORM clojure:temurin-21-jammy AS builder
 
 WORKDIR /app
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,6 +38,19 @@ on any CPU architecture supported by Java 21 (x86-64, arm64, …).
 
 __ https://github.com/dimitri/pgloader/releases
 
+Docker image (v4)
+^^^^^^^^^^^^^^^^^
+
+A multi-arch Docker image for v4 is published to the GitHub Container Registry
+after every green push to ``main`` (as ``:latest``) and for every tagged release::
+
+    docker pull ghcr.io/dimitri/pgloader-v4:latest
+    docker run --rm ghcr.io/dimitri/pgloader-v4:latest --version
+    docker run --rm -v $(pwd):/work ghcr.io/dimitri/pgloader-v4:latest /work/my.load
+
+The image supports **linux/amd64** and **linux/arm64** natively — no emulation
+layer is needed on arm64 hosts (AWS Graviton, Apple Silicon, Raspberry Pi, …).
+
 .. _install_v3:
 
 pgloader v3 — Common Lisp


### PR DESCRIPTION
Closes #1587.

## What

Adds a new `.github/workflows/docker-publish-v4.yml` that builds and publishes a **linux/amd64 + linux/arm64** Docker image for the Clojure/JVM v4 build to `ghcr.io/dimitri/pgloader-v4`.

### Why v4 is the right place for multi-arch

The JVM is ideal for this: `clojure -T:build uber` produces a platform-independent JAR. The `clojure/Dockerfile` builder stage now uses `--platform=$BUILDPLATFORM`, so the Clojure compilation always runs **natively** on the GitHub Actions host (linux/amd64). QEMU is only needed for the small runtime stage (creating a non-root user, a few shell commands) — trivially fast. There is no multi-hour SBCL cross-compilation under emulation.

The v3 SBCL image is a different story: compiling Common Lisp natively under QEMU takes 2–4 hours on a standard runner, making arm64 there impractical without self-hosted arm64 runners.

### Publication strategy

Mirrors the existing v3 workflow:

| Event | Tag |
|-------|-----|
| push to `main` | `ghcr.io/dimitri/pgloader-v4:latest` |
| semver tag push | `ghcr.io/dimitri/pgloader-v4:<version>` |
| pull request | build only, no push |

A separate image name (`pgloader-v4`) avoids any tag collision with the v3 `pgloader` image.

## Changes

- **`clojure/Dockerfile`** — add `--platform=$BUILDPLATFORM` to the builder stage
- **`.github/workflows/docker-publish-v4.yml`** — new workflow (QEMU + buildx + multi-arch push + GHA layer cache + cosign signing)
- **`docs/install.rst`** — add "Docker image (v4)" subsection mentioning `ghcr.io/dimitri/pgloader-v4:latest` and its arm64 support