### PR TITLE
fix(truncate): include materialized views in TRUNCATE

### DIFF
--- a/src/pgsql/pgsql-create-schema.lisp
+++ b/src/pgsql/pgsql-create-schema.lisp
@@ -302,8 +302,10 @@
    must already be active when calling that function."
   (let* ((target-list (mapcar #'format-table-name
                               (etypecase catalog-or-table
-                                (catalog (table-list catalog-or-table))
-                                (schema  (table-list catalog-or-table))
+                                (catalog (append (table-list catalog-or-table)
+                                                 (view-list  catalog-or-table)))
+                                (schema  (append (table-list catalog-or-table)
+                                                 (view-list  catalog-or-table)))
                                 (table   (list catalog-or-table)))))
          (sql
           (when target-list


### PR DESCRIPTION
## Problem

When using `MATERIALIZE VIEWS view_name AS $$ SELECT ... $$` together with `WITH truncate`, the pre-COPY TRUNCATE step silently skips every materialized view.

The root cause: `fetch-metadata` calls `fetch-columns` with `:table-type :view` for materialized views, so they land in `schema-view-list` rather than `schema-table-list`. `truncate-tables` built its target list exclusively from `(table-list catalog)`, which only returns `schema-table-list` entries. The TRUNCATE SQL was therefore never generated for any matview regardless of any subsequent `ALTER TABLE NAMES MATCHING ... RENAME TO`.

The COPY phase already did the right thing — `optimize-table-copy-ordering` uses `(nconc table-list view-list)` — but the TRUNCATE step had not been updated to match.

## Fix

Include `(view-list catalog-or-table)` alongside `(table-list catalog-or-table)` in the `catalog` and `schema` branches of `truncate-tables`. The `table` branch is unchanged (a single table object is always concrete).

## v4 status

Not affected. Matviews with an explicit SQL definition are handled by `materialize-views!` which always runs `DROP TABLE IF EXISTS` + `CREATE TABLE` before COPY. Matviews without an explicit SQL definition are merged into `cat` and go through the regular per-entry TRUNCATE loop. Neither path has this miss.

Closes #1591.