### PR TITLE
build: fix v3 bundle for SBCL 2.6.5; add bundle CI; fix smoke-test trigger

### DIFF
--- a/.github/workflows/bundle-ci.yml
+++ b/.github/workflows/bundle-ci.yml
@@ -43,9 +43,10 @@ jobs:
         run: make bundle
 
       - name: Run regression suite against bundle binary
-        # pg_virtualenv spins up a throwaway PostgreSQL cluster so the
-        # regress tests can create/drop databases freely.
+        # pg_virtualenv spins up a throwaway PostgreSQL cluster whose
+        # superuser is the current OS user (not 'postgres').  Pass that
+        # name via PGSUPERUSER so the test Makefile's createdb/psql calls
+        # use the right role — mirroring what debian/tests/testsuite does.
         run: |
-          PGSUPERUSER=postgres \
           pg_virtualenv -i'-Atrust' \
-          make test-bundle
+            env PGSUPERUSER="$(id -un)" make test-bundle

--- a/.github/workflows/bundle-ci.yml
+++ b/.github/workflows/bundle-ci.yml
@@ -1,0 +1,51 @@
+name: Quicklisp bundle build & regression test
+
+# Runs when anything that affects the v3 bundle changes: the bundle
+# machinery itself, the Makefile (which holds BUNDLEDIST), or the Lisp
+# source that gets compiled into the bundle binary.
+on:
+  pull_request:
+    paths:
+      - 'Makefile'
+      - 'bundle/**'
+      - 'src/**'
+      - '.github/workflows/bundle-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Makefile'
+      - 'bundle/**'
+      - 'src/**'
+      - '.github/workflows/bundle-ci.yml'
+
+jobs:
+  bundle:
+    name: Build and test from Quicklisp bundle
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install postgresql-common
+        run: sudo apt-get install -y postgresql-common
+
+      - name: Install pgapt repository
+        run: sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+
+      - name: Install build dependencies
+        run: sudo apt-get build-dep -y .
+
+      - name: Build Quicklisp bundle
+        # Downloads the pinned Quicklisp dist (BUNDLEDIST in Makefile),
+        # creates the self-contained bundle tarball, extracts it, compiles
+        # pgloader from the bundled sources, and smoke-tests with --version.
+        run: make bundle
+
+      - name: Run regression suite against bundle binary
+        # pg_virtualenv spins up a throwaway PostgreSQL cluster so the
+        # regress tests can create/drop databases freely.
+        run: |
+          PGSUPERUSER=postgres \
+          pg_virtualenv -i'-Atrust' \
+          make test-bundle

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,14 +3,21 @@ name: Smoke test — published JAR
 # Runs whenever the v4-dev pre-release is updated (i.e. after every green CI
 # push that publishes a new JAR), and can also be triggered manually.
 on:
-  release:
-    types: [prereleased]
+  # Fires automatically after the integration-tests workflow publishes a new
+  # JAR to the v4-dev pre-release on main.  Using workflow_run rather than
+  # release: prereleased because updating assets on an existing pre-release
+  # does not re-fire the release event.
+  workflow_run:
+    workflows: ["pgloader v4 Integration Tests"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   smoke:
     name: Download JAR & migrate Chinook SQLite → PostgreSQL
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     services:
       postgres:

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ $(BUNDLE): $(BUNDLEDIR) $(BUNDLEDIR)/version.sexp
 	cp bundle/README.md $(BUNDLEDIR)
 	cp bundle/save.lisp $(BUNDLEDIR)
 	sed -e s/%VERSION%/$(VERSION)/ < bundle/Makefile > $(BUNDLEDIR)/Makefile
-	git archive --format=tar --prefix=pgloader-$(VERSION)/ main \
+	git archive --format=tar --prefix=pgloader-$(VERSION)/ HEAD \
 	     | tar -C $(BUNDLEDIR)/local-projects/ -xf -
 	make QLDIR=$(BUNDLEDIR) clones
 	tar -C build/bundle 		    \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ QLDIR      = $(BUILDDIR)/quicklisp
 MANIFEST   = $(BUILDDIR)/manifest.ql
 LATEST     = $(BUILDDIR)/pgloader-latest.tgz
 
-BUNDLEDIST = 2022-02-20
+BUNDLEDIST = 2026-01-01
 BUNDLENAME = pgloader-bundle-$(VERSION)
 BUNDLEDIR  = $(BUILDDIR)/bundle/$(BUNDLENAME)
 BUNDLE     = $(BUILDDIR)/$(BUNDLENAME).tgz

--- a/bundle/Makefile
+++ b/bundle/Makefile
@@ -62,7 +62,7 @@ $(PGLOADER): $(BUILDAPP)
 	mv $@.tmp $@
 
 test: $(PGLOADER)
-	$(MAKE) PGLOADER=$(realpath $(PGLOADER)) -C $(SRCDIR)/test regress
+	$(MAKE) PGLOADER=$(realpath $(PGLOADER)) -C $(SRCDIR)/test prepare regress
 
 save:
 	sbcl --no-userinit --load ./save.lisp

--- a/debian/rules
+++ b/debian/rules
@@ -74,11 +74,10 @@ override_dh_strip override_dh_dwz:
 
 override_dh_installman-arch:
 	mkdir -p debian/pgloader/usr/share/man/man1/
-	PATH=$(CURDIR)/debian/pgloader/usr/bin:$(PATH) \
 	help2man --version-string $(DEB_VERSION_UPSTREAM) \
 		--no-info \
 		--name "extract, transform and load data into PostgreSQL" \
-		pgloader > \
+		$(CURDIR)/debian/pgloader/usr/bin/pgloader > \
 		debian/pgloader/usr/share/man/man1/pgloader.1
 
 override_dh_gencontrol:


### PR DESCRIPTION
## Problem

The bundle has been pinned to Quicklisp dist `2022-02-20` since pgloader 3.6.8. That snapshot ships `named-readtables-20220220-git`, which fails to build under SBCL 2.6.5 (#1703).

Root cause: SBCL 2.6.5 changed the internal char-macro array to store `0` instead of `NIL` for absent macro characters. The old `named-readtables` iterator tested `(if reader-fn ...)` — truthy for `0` — so it yielded characters with no real macro function attached. `check-reader-macro-conflict` then found a `0` where it expected a function and signalled an assertion error.

## Changes

**`Makefile`** — bump `BUNDLEDIST` from `2022-02-20` to `2026-01-01`, the most recent available Quicklisp dist. That dist ships `named-readtables-20260101-git` (upstream fix by melisgl, 2025-11-09): the `grovel-base-chars` iterator now tests `(and reader-fn (not (eql reader-fn 0)))` before yielding. Also picks up ~4 years of other dependency updates.

**`debian/rules`** — fix intermittent `help2man` failure (exit 127) in the Debian package build. The `override_dh_installman-arch` recipe was calling `help2man pgloader` and relying on a `PATH=` prefix to locate the binary; that PATH wasn't consistently inherited by help2man's subprocess. Pass the full path directly instead.

**`.github/workflows/bundle-ci.yml`** — new CI workflow that builds pgloader from the Quicklisp bundle and runs the full regression suite. Triggers on `Makefile`, `bundle/**`, or `src/**` changes. Uses `pg_virtualenv` to spin up a throwaway PostgreSQL cluster, mirroring how `debian/tests/testsuite` runs autopkgtest.

**`bundle/Makefile`** — add `prepare` before `regress` in the `test` target. Without it `make test-bundle` called `make regress` directly against databases that hadn't been created yet.

**`.github/workflows/smoke-test.yml`** — fix smoke-test trigger. The previous `release: prereleased` event never fired because `softprops/action-gh-release` updates an existing pre-release rather than re-creating it, and GitHub only fires `prereleased` on initial publication. Switch to `workflow_run` triggered after `pgloader v4 Integration Tests` completes successfully on main — i.e. exactly when the JAR is actually updated.

## Validation

The new `bundle-ci.yml` workflow runs `make bundle` (downloads pinned dist, compiles, checks `--version`) followed by `make test-bundle` (full regression suite against the bundle binary).

Closes #1703.