### PR TITLE
fix(mssql): remove invalid auth modes; suppress azure-identity log noise (#1754 follow-up)

### DIFF
--- a/clojure/resources/logback.xml
+++ b/clojure/resources/logback.xml
@@ -21,6 +21,13 @@
     </encoder>
   </appender>
 
+  <!-- azure-identity logs every credential it tries in its DefaultAzureCredential
+       chain (EnvironmentCredential unavailable, WorkloadIdentity unavailable,
+       ManagedIdentity unavailable, etc.) at INFO/WARN — expected on a developer
+       machine but very noisy. Suppress to WARN/ERROR respectively. -->
+  <logger name="com.azure.identity" level="WARN"/>
+  <logger name="com.microsoft.aad.msal4j" level="ERROR"/>
+
   <root level="INFO">
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="FILE"/>

--- a/clojure/test/pgloader/load_file/ast_test.clj
+++ b/clojure/test/pgloader/load_file/ast_test.clj
@@ -95,12 +95,12 @@
         "com.microsoft.aad.msal4j must be on the classpath for ActiveDirectoryPassword / ActiveDirectoryServicePrincipal auth")))
 
 (deftest test-azure-identity-on-classpath
-  (testing "azure-identity is bundled — ActiveDirectoryDefault / AzCli / WorkloadIdentity auth modes are available"
+  (testing "azure-identity is bundled — ActiveDirectoryDefault auth mode is available"
     (is (try (Class/forName "com.azure.identity.DefaultAzureCredentialBuilder")
              true
              (catch ClassNotFoundException _
                false))
-        "com.azure.identity must be on the classpath for ActiveDirectoryDefault / ActiveDirectoryAzCli / ActiveDirectoryWorkloadIdentity auth")))
+        "com.azure.identity must be on the classpath for ActiveDirectoryDefault auth")))
 
 (deftest test-parse-postgresql-synthesises-jdbc-url
   (testing "postgresql:// synthesises jdbc-url"

--- a/docs/ref/mssql.rst
+++ b/docs/ref/mssql.rst
@@ -356,21 +356,21 @@ and ``authentication=`` reach the driver exactly as written.
 
 Quick reference:
 
-+--------------------------------------+------------------------------------------------+
-| Mode                                 | Typical use case                               |
-+======================================+================================================+
-| ``ActiveDirectoryServicePrincipal``  | CI/CD — app registration (client ID + secret)  |
-+--------------------------------------+------------------------------------------------+
-| ``ActiveDirectoryManagedIdentity``   | Azure VM / App Service / AKS — no credentials |
-+--------------------------------------+------------------------------------------------+
-| ``ActiveDirectoryDefault``           | Developer laptop: ``az login`` fallback chain  |
-+--------------------------------------+------------------------------------------------+
-| ``ActiveDirectoryAzCli``             | Developer laptop: explicit ``az login`` token  |
-+--------------------------------------+------------------------------------------------+
-| ``ActiveDirectoryWorkloadIdentity``  | Kubernetes OIDC workload identity              |
-+--------------------------------------+------------------------------------------------+
-| ``ActiveDirectoryPassword``          | **Deprecated** — blocked by MFA enforcement    |
-+--------------------------------------+------------------------------------------------+
++--------------------------------------------+------------------------------------------------+
+| Mode                                       | Typical use case                               |
++============================================+================================================+
+| ``ActiveDirectoryServicePrincipal``        | CI/CD — app registration (client ID + secret)  |
++--------------------------------------------+------------------------------------------------+
+| ``ActiveDirectoryServicePrincipalCertif.`` | CI/CD — app registration with certificate      |
++--------------------------------------------+------------------------------------------------+
+| ``ActiveDirectoryManagedIdentity``         | Azure VM / App Service / AKS — no credentials |
++--------------------------------------------+------------------------------------------------+
+| ``ActiveDirectoryDefault``                 | Developer laptop: ``az login`` fallback chain  |
++--------------------------------------------+------------------------------------------------+
+| ``ActiveDirectoryIntegrated``              | Windows / Kerberos domain-joined machine       |
++--------------------------------------------+------------------------------------------------+
+| ``ActiveDirectoryPassword``                | **Deprecated** — blocked by MFA enforcement    |
++--------------------------------------------+------------------------------------------------+
 
 ``ActiveDirectoryServicePrincipal``
     Authenticate as an Azure AD application (client ID + client secret) —
@@ -402,19 +402,12 @@ authentication=ActiveDirectoryDefault;encrypt=true;trustServerCertificate=false"
     get-access-token`` using your existing ``az login`` session — no browser
     popup is needed.
 
-``ActiveDirectoryAzCli``
-    Like ``ActiveDirectoryDefault`` but always uses the Azure CLI token
-    exclusively.  Useful when you want a predictable, unambiguous credential
-    source on a developer machine::
+``ActiveDirectoryIntegrated``
+    Authenticate via Kerberos on a domain-joined machine.  Requires a valid
+    Kerberos ticket (``kinit`` on Linux/macOS, automatic on Windows)::
 
         FROM "jdbc:sqlserver://myserver.database.windows.net:1433;databaseName=mydb;\
-authentication=ActiveDirectoryAzCli;encrypt=true;trustServerCertificate=false"
-
-``ActiveDirectoryWorkloadIdentity``
-    For Kubernetes pods with OIDC workload identity federation::
-
-        FROM "jdbc:sqlserver://myserver.database.windows.net:1433;databaseName=mydb;\
-authentication=ActiveDirectoryWorkloadIdentity;encrypt=true"
+authentication=ActiveDirectoryIntegrated;encrypt=true"
 
 ``ActiveDirectoryPassword``
     .. note::


### PR DESCRIPTION
Follow-up to #1755, reported by @audunsolemdal in #1754.

## Fixes

### 1. Remove `ActiveDirectoryAzCli` and `ActiveDirectoryWorkloadIdentity` from docs

These modes do **not exist** in `mssql-jdbc` 12.6.1. Confirmed via `javap` on the `SqlAuthentication` enum — the valid values are:
`NotSpecified`, `SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryServicePrincipal`, `ActiveDirectoryServicePrincipalCertificate`, `ActiveDirectoryInteractive`, `ActiveDirectoryDefault`.

`ActiveDirectoryAzCli` and `ActiveDirectoryWorkloadIdentity` exist only in the .NET (`Microsoft.Data.SqlClient`) and Go (`go-mssqldb`) drivers. Using either in the Java driver throws immediately:
```
SQLServerException: The authentication value "ActiveDirectoryAzCli" is not valid.
```

Replace with `ActiveDirectoryIntegrated` (Kerberos) and `ActiveDirectoryServicePrincipalCertificate` which are valid mssql-jdbc modes.

### 2. Suppress verbose azure-identity chain probe logging

`ActiveDirectoryDefault` walks `DefaultAzureCredential`'s chain on every new connection, emitting INFO-level messages for each unavailable credential (`EnvironmentCredential unavailable`, `ManagedIdentityCredential unavailable`, etc.) — very noisy on a developer machine where most credential types aren't configured, and multiplied by pgloader's connection pool thread count.

Add to `logback.xml`:
```xml
<logger name="com.azure.identity" level="WARN"/>
<logger name="com.microsoft.aad.msal4j" level="ERROR"/>
```

This silences the expected chain traversal noise while preserving genuine warnings and errors.