### PR TITLE
Support custom transformation rules in Clojure

### DIFF
--- a/clojure/src/pgloader/load_file/ast.clj
+++ b/clojure/src/pgloader/load_file/ast.clj
@@ -3,8 +3,11 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [pgloader.pg-service :as pg-service]
-            [pgloader.mysql-options :as mysql-opts])
+            [pgloader.mysql-options :as mysql-opts]
+            [pgloader.transforms :refer [compile-using-expr]])
   (:import [java.net URI]))
+
+(declare s-expr-content)
 
 (set! *warn-on-reflection* true)
 
@@ -295,8 +298,18 @@
                        (clojure.string/join " " (map second (filter #(= :word-part (first %)) (rest target-inner)))))))
           using-fn (some (fn [n]
                            (when (and (vector? n) (= :using-fn (first n)))
-                             (keyword (second (some #(when (and (vector? %) (= :fn-name (first %))) %)
-                                                    (rest n))))))
+                             (let [expr-node (some #(when (and (vector? %)
+                                                                 (or (= :fn-name (first %))
+                                                                     (= :s-expr (first %))
+                                                                     (= :reader-fn (first %))))
+                                                       %)
+                                                     (rest n))]
+                               (case (first expr-node)
+                                 :fn-name   (keyword (second expr-node))
+                                 :s-expr    (compile-using-expr
+                                              (str "(" (s-expr-content expr-node) ")"))
+                                 :reader-fn (compile-using-expr
+                                              (str "#(" (s-expr-content (second expr-node)) ")"))))))
                          flat-cast-opts)
           when-node (first (filter #(= :when-or-unsigned (first %)) inner-children))
           when-cond (when when-node

--- a/clojure/src/pgloader/load_file/grammar.clj
+++ b/clojure/src/pgloader/load_file/grammar.clj
@@ -266,7 +266,7 @@
     keep-not-null = <'keep'> <ws> <'not'> <ws> <'null'>
     drop-typemod  = <'drop'> <ws> <'typemod'>
     keep-typemod  = <'keep'> <ws> <'typemod'>
-    using-fn      = <'using'> <ws> fn-name
+    using-fn      = <'using'> <ws> (s-expr | reader-fn | fn-name)
     fn-name     = #'[a-zA-Z][a-zA-Z0-9_-]*'
     when-or-unsigned = <'when'> <ws> (when-expr | <'unsigned'> | <'default'> <ws> when-default-val) (<ws> when-not-null)?
     when-not-null = <'and'> <ws> <'not'> <ws> <'null'>


### PR DESCRIPTION
I need to migrate some data from a MySQL database into PostgreSQL, where in the original schema some columns use `longblob` datatype, but when the application is connected to PostgreSQL, it expects to read plain text, something that it can process as VARCHAR in its SQL library.

The application in question is Znuny.

The documentation brought me onto the idea of using custom transformation rules, which worked fine with pgloader 3.6 and the lisp files.

In the clojure rewrite, `clojure/src/pgloader/transforms.clj`, it is stated that custom transform functions can be used, but my AI helper and I could not get it to work.

It seems like pgloaders grammar currently doesn't handle this.

I've had my AI helper produce a patch to support this, which I am sending in this PR.

To be perfectly honest, I don't know anything about Clojure and I cannot attest that there are no side effects or other weirdnesses introduced by this, but it seems to work for my usecase.


Other points to eventually fix would be to update the Documentation (which still talks about Lisp transformers), and possibly to think about using files to hand over clojure funcions, as defining them in the `CAST` section of a .load file (and repeating them for each of the 25 columns that require this same treatment) is a bit unsightly.

Disclosure: This patch was written by AI. This description of the PR was written by me.